### PR TITLE
chore(types): regenerate openapi.json + types from agno 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ This project follows [Semantic Versioning](https://semver.org/).
 - Regenerated `openapi.json` and `src/generated/types.ts` from an AgentOS running
   agno 3.0.0. The committed spec predated 2.8.5 (76 paths); the new capture has
   117 paths and 187 schemas. No route was removed and no schema key used by
-  `src/resources/*` disappeared, so the regeneration is additive for callers.
+  `src/resources/*` disappeared, so every hand-written resource method keeps
+  working unchanged. It is **not** additive for consumers, though: `src/index.ts`
+  re-exports `components` and `paths`, so the schema changes below are part of
+  this package's public type surface. See **Breaking** for the source-breaking
+  subset.
   - New routes: `/info`, `/toolsets`, `/toolsets/{name}`, `/learnings*`,
     `/service-accounts*`, agent/team/workflow `runs/{run_id}/resume` and
     `runs/{run_id}/checkpoints`, `sessions/{session_id}/fork`,
@@ -31,6 +35,28 @@ This project follows [Semantic Versioning](https://semver.org/).
     `ComponentResponse`; `ScheduleResponse` also gained `managed_by`, `target_type`,
     `target_id` and `disabled_reason`.
   - `Body_create_agent_run.version` changed from `string` to `integer`.
+
+### Breaking
+
+Consumers that type-reference the re-exported `components`/`paths` are affected
+by the regeneration. Under `strict` TypeScript these are compile errors, not
+warnings:
+
+- `error_code` is gone from every error schema; read `error_id` / `error_type`
+  instead (`ValidationErrorResponse` carries neither).
+- `ConfigResponse.available_models` is `Model[]` (`{ id, provider }`), not
+  `string[] | null` — element member access changes.
+- `VectorSearchResult.id` is now optional and nullable (`string | null`) rather
+  than a required `string`. This is the element type of `knowledge.search()`
+  results, so `r.id` needs a null guard.
+- `EvalsConfig` and `EvalsDomainConfig` no longer carry `available_models`.
+- `Body_create_agent_run.version` is `integer`, not `string`.
+- `ValidationErrorResponse.detail` widened to `string | ValidationErrorDetail[]`.
+- Enums grew, which breaks exhaustive `switch`/never-checks: `RunStatus` gained
+  `REGENERATED`; `RegistryResourceType` gained `workflow`, `knowledge`,
+  `memory_manager`, `session_summary_manager` and `learning`.
+
+Release note: this warrants a minor bump (0.7.0), not a patch.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Regenerated `openapi.json` and `src/generated/types.ts` from an AgentOS running
+  agno 3.0.0. The committed spec predated 2.8.5 (76 paths); the new capture has
+  117 paths and 187 schemas. No route was removed and no schema key used by
+  `src/resources/*` disappeared, so the regeneration is additive for callers.
+  - New routes: `/info`, `/toolsets`, `/toolsets/{name}`, `/learnings*`,
+    `/service-accounts*`, agent/team/workflow `runs/{run_id}/resume` and
+    `runs/{run_id}/checkpoints`, `sessions/{session_id}/fork`,
+    `teams|workflows/{id}/runs/{run_id}/continue`, `PATCH /agents/{agent_id}/model`,
+    `PATCH /teams/{team_id}/model`, `POST /agents:apply`, `DELETE /agents/{component_id}`,
+    `POST /components/{component_id}/restore`, `GET /metrics/refresh/status`,
+    `GET /sessions/{session_id}/media/{storage_key}`, `GET /workflows/{workflow_id}/runs`,
+    the `/a2a/*` interface routes, and the `/queue` stub routes.
+  - Error payloads: `error_code` is gone from `BadRequestResponse`,
+    `NotFoundResponse`, `UnauthenticatedResponse`, `InternalServerErrorResponse`
+    and `ValidationErrorResponse`; the first four now carry `error_id` and
+    `error_type`. `ValidationErrorResponse.detail` widened to
+    `string | ValidationErrorDetail[]`.
+  - `ConfigResponse.available_models` changed from `string[] | null` to `Model[]`
+    (`{ id, provider }`).
+  - `user_id` added to `EvalSchema`, `ScheduleResponse`, `ScheduleRunResponse` and
+    `ComponentResponse`; `ScheduleResponse` also gained `managed_by`, `target_type`,
+    `target_id` and `disabled_reason`.
+  - `Body_create_agent_run.version` changed from `string` to `integer`.
+
+### Added
+
+- `GetMetricsOptions.userId`, sent as the `user_id` query param on `GET /metrics`.
+
+
 ## [0.6.1] - 2026-06-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -544,9 +544,18 @@ type ListAgentsPath = paths['/agents']['get'];
 
 The SDK generates TypeScript types directly from the AgentOS OpenAPI specification:
 
+- Capture the spec from a running AgentOS: `curl -s $BASE_URL/openapi.json`,
+  written to `openapi.json` as JSON with 2-space indentation
 - Run `npm run generate:types` to regenerate types from `openapi.json`
 - Types are committed to git in `src/generated/types.ts`
 - All resource methods use generated types for request/response bodies
+
+One normalization is applied to the captured spec by hand and must be reapplied
+after each capture: agno 3.0.0 gives both `GET /config` and
+`GET /components/{component_id}/configs/{version}` the `operation_id` `get_config`,
+which makes `openapi-typescript` emit a duplicate `operations` key and fails
+`npm run typecheck`. The second one is renamed to `get_config_version` (the name
+of its handler) in `openapi.json`.
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -545,7 +545,13 @@ type ListAgentsPath = paths['/agents']['get'];
 The SDK generates TypeScript types directly from the AgentOS OpenAPI specification:
 
 - Capture the spec from a running AgentOS: `curl -s $BASE_URL/openapi.json`,
-  written to `openapi.json` as JSON with 2-space indentation
+  written to `openapi.json` as JSON with 2-space indentation. **Capture from a
+  stack that also mounts the auth, models, registry and agent-builder routers**
+  (an ixora stack does) — a stock agno AgentOS does not serve `/auth/*`,
+  `GET /models`, `/registry/*`, `/toolsets*` or `POST /agents:apply`, and
+  capturing from one drops the schemas that `src/resources/auth.ts`,
+  `models.ts` and `registry.ts` reference, so `npm run typecheck` then fails on
+  hand-written code that was never touched.
 - Run `npm run generate:types` to regenerate types from `openapi.json`
 - Types are committed to git in `src/generated/types.ts`
 - All resource methods use generated types for request/response bodies

--- a/openapi.json
+++ b/openapi.json
@@ -556,6 +556,160 @@
         }
       }
     },
+    "/agents:apply": {
+      "post": {
+        "tags": [
+          "agents-builder"
+        ],
+        "summary": "Apply Agent",
+        "description": "Create, apply (upsert), or update an IBM i agent from a friendly manifest.",
+        "operationId": "apply_agent_agents_apply_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplyAgentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplyAgentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{component_id}": {
+      "delete": {
+        "tags": [
+          "agents-builder"
+        ],
+        "summary": "Delete Agent",
+        "description": "Delete a DB-backed agent component.",
+        "operationId": "delete_agent_agents__component_id__delete",
+        "parameters": [
+          {
+            "name": "component_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Agent / component id",
+              "title": "Component Id"
+            },
+            "description": "Agent / component id"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/toolsets": {
+      "get": {
+        "tags": [
+          "agents-builder"
+        ],
+        "summary": "List Toolsets Route",
+        "description": "List the curated IBM i toolset catalog (name, title, description, tool_count).",
+        "operationId": "list_toolsets_route_toolsets_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "type": "array",
+                  "title": "Response List Toolsets Route Toolsets Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/toolsets/{name}": {
+      "get": {
+        "tags": [
+          "agents-builder"
+        ],
+        "summary": "Get Toolset Route",
+        "description": "Return one toolset's raw entry (tools, source, title, description, tool_metadata).",
+        "operationId": "get_toolset_route_toolsets__name__get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Toolset name",
+              "title": "Name"
+            },
+            "description": "Toolset name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Toolset Route Toolsets  Name  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/health": {
       "get": {
         "tags": [
@@ -582,6 +736,28 @@
         }
       }
     },
+    "/info": {
+      "get": {
+        "tags": [
+          "Core"
+        ],
+        "summary": "Get OS Info",
+        "description": "Return lightweight, unauthenticated metadata about this AgentOS instance.",
+        "operationId": "get_info",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InfoResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/config": {
       "get": {
         "tags": [
@@ -601,7 +777,16 @@
                 "example": {
                   "id": "demo",
                   "description": "Example AgentOS configuration",
-                  "available_models": [],
+                  "available_models": [
+                    {
+                      "id": "gpt-4",
+                      "provider": "openai"
+                    },
+                    {
+                      "id": "claude-3-sonnet",
+                      "provider": "anthropic"
+                    }
+                  ],
                   "databases": [
                     "9c884dc4-9066-448c-9074-ef49ec7eb73c"
                   ],
@@ -666,97 +851,6 @@
                   "workflows": [],
                   "interfaces": []
                 }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequestResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthenticatedResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFoundResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ]
-      }
-    },
-    "/models": {
-      "get": {
-        "tags": [
-          "Core"
-        ],
-        "summary": "Get Available Models",
-        "description": "Retrieve a list of all unique models currently used by agents and teams in this OS instance. This includes the model ID and provider information for each model.",
-        "operationId": "get_models",
-        "responses": {
-          "200": {
-            "description": "List of models retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "$ref": "#/components/schemas/Model"
-                  },
-                  "type": "array",
-                  "title": "Response Get Models"
-                },
-                "example": [
-                  {
-                    "id": "gpt-4",
-                    "provider": "openai"
-                  },
-                  {
-                    "id": "claude-3-sonnet",
-                    "provider": "anthropic"
-                  }
-                ]
               }
             }
           },
@@ -1066,6 +1160,24 @@
               "type": "string",
               "title": "Run Id"
             }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session ID the run belongs to. Required for non-admin JWT users.",
+              "title": "Session Id"
+            },
+            "description": "Session ID the run belongs to. Required for non-admin JWT users."
           }
         ],
         "responses": {
@@ -1136,7 +1248,7 @@
           "Agents"
         ],
         "summary": "Continue Agent Run",
-        "description": "Continue a paused or incomplete agent run with updated tool results.\n\n**Use Cases:**\n- Resume execution after tool approval/rejection\n- Provide manual tool execution results\n- Resume after admin approval (tools can be empty; resolution fetched from DB)\n\n**Tools Parameter:**\nJSON string containing array of tool execution objects with results.\nCan be empty when an admin-required approval has been resolved.",
+        "description": "Advance a persisted agent run from its current state. Dispatches on the body shape and the persisted run state.\n\n**Variants:**\n- PAUSED + tools provided \u2192 apply HITL tool results, resume\n- PAUSED + resolved admin approval (empty tools) \u2192 apply resolution, resume\n- RUNNING / ERROR (no unresolved HITL requirements) \u2192 resume from last persisted state\n- COMPLETED + new tools \u2192 continue with appended messages\n\n**Tools Parameter:**\nJSON string containing array of tool execution objects with results. Optional \u2014 only required when the persisted run has unresolved HITL requirements.",
         "operationId": "continue_agent_run",
         "security": [
           {
@@ -1238,7 +1350,118 @@
             "description": "Run has a pending admin approval and cannot be continued by the user yet."
           },
           "409": {
-            "description": "Run is not paused (e.g. run is already running, continued, or errored). Only PAUSED runs can be continued."
+            "description": "Continuation conflict: a durable queue ticket owns this run's continuation (continue it with background=true), or a continuation is already queued or executing. Runs in any state can be continued - a COMPLETED run forks into a follow-up; RUNNING/ERROR runs resume."
+          }
+        }
+      }
+    },
+    "/agents/{agent_id}/sessions/{session_id}/fork": {
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Fork Agent Session",
+        "description": "Deep-copy a session into a new independent session. Every run is copied with a fresh ``run_id``; the new session has a fresh ``session_id``. The original is untouched. Use to explore alternative conversation paths without mutating the source.\n\nDistinct from ``/continue?fork=true``: that creates a sibling **run** inside the **same** session. This creates a sibling **session**.",
+        "operationId": "fork_agent_session",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session forked successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Source session is empty or missing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -1560,6 +1783,332 @@
         }
       }
     },
+    "/agents/{agent_id}/runs/{run_id}/checkpoints": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "List Agent Run Checkpoints",
+        "description": "List FE-friendly continuation boundaries derived from the current stored run. No separate checkpoint table is used; entries are inferred from message-level checkpoint markers and the terminal end of the transcript.",
+        "operationId": "list_agent_run_checkpoints",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Session ID for the run",
+              "title": "Session Id"
+            },
+            "description": "Session ID for the run"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run checkpoints retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent or run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{agent_id}/runs/{run_id}/checkpoints/{message_index}": {
+      "get": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Get Agent Run Checkpoint Snapshot",
+        "description": "Return a derived run snapshot truncated at a message boundary. Use the returned message_index as `continue_from` when continuing this run.",
+        "operationId": "get_agent_run_checkpoint_snapshot",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "message_index",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Message Index"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Session ID for the run",
+              "title": "Session Id"
+            },
+            "description": "Session ID for the run"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run checkpoint snapshot retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid checkpoint message index",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent or run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/{agent_id}/runs/{run_id}/resume": {
+      "post": {
+        "tags": [
+          "Agents"
+        ],
+        "summary": "Resume Agent Run Stream",
+        "description": "Resume an SSE stream for an agent run after disconnection.\n\nSends missed events since `last_event_index`, then continues streaming live events if the run is still active.\n\n**Three reconnection paths:**\n1. **Run still active**: Sends catch-up events + continues live streaming\n2. **Run completed (in buffer)**: Replays missed buffered events\n3. **Run completed (in database)**: Replays events from database\n\n**Client usage:**\nTrack `event_index` from each SSE event. On reconnection, pass the last received `event_index` as `last_event_index`.",
+        "operationId": "resume_agent_run_stream",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_resume_agent_run_stream"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "SSE stream of catch-up and/or live events",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/event-stream": {}
+            }
+          },
+          "400": {
+            "description": "Not supported for remote agents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/teams/{team_id}/runs": {
       "post": {
         "tags": [
@@ -1803,6 +2352,24 @@
               "type": "string",
               "title": "Run Id"
             }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session ID the run belongs to. Required for non-admin JWT users.",
+              "title": "Session Id"
+            },
+            "description": "Session ID the run belongs to. Required for non-admin JWT users."
           }
         ],
         "responses": {
@@ -1856,6 +2423,335 @@
           },
           "500": {
             "description": "Failed to cancel team run",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/{team_id}/runs/{run_id}/resume": {
+      "post": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "Resume Team Run Stream",
+        "description": "Resume an SSE stream for a team run after disconnection.\n\nSends missed events since `last_event_index`, then continues streaming live events if the run is still active.\n\n**Three reconnection paths:**\n1. **Run still active**: Sends catch-up events + continues live streaming\n2. **Run completed (in buffer)**: Replays missed buffered events\n3. **Run completed (in database)**: Replays events from database\n\n**Client usage:**\nTrack `event_index` from each SSE event. On reconnection, pass the last received `event_index` as `last_event_index`.",
+        "operationId": "resume_team_run_stream",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Team Id"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_resume_team_run_stream"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "SSE stream of catch-up and/or live events",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/event-stream": {}
+            }
+          },
+          "400": {
+            "description": "Not supported for remote teams",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Team not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/{team_id}/runs/{run_id}/continue": {
+      "post": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "Continue Team Run",
+        "description": "Continue a paused or incomplete team run with updated requirements.\n\n**Use Cases:**\n- Resume execution after tool approval/rejection\n- Provide manual tool execution results\n- Resume after admin approval (requirements can be empty; resolution fetched from DB)\n\n**Requirements Parameter:**\nJSON string containing array of requirement objects with tool execution results.\nCan be empty when an admin-required approval has been resolved.",
+        "operationId": "continue_team_run",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Team Id"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_continue_team_run"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Team run continued successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/event-stream": {
+                "example": "event: RunContent\ndata: {\"created_at\": 1757348314, \"run_id\": \"123...\"}\n\n"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON in requirements field or invalid requirement structure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Team not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Run has a pending admin approval and cannot be continued by the user yet."
+          },
+          "409": {
+            "description": "Continuation conflict: a durable queue ticket owns this run's continuation (continue it with background=true), or a continuation is already queued or executing. Runs in any state can be continued - a COMPLETED run forks into a follow-up; RUNNING/ERROR runs resume."
+          }
+        }
+      }
+    },
+    "/teams/{team_id}/sessions/{session_id}/fork": {
+      "post": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "Fork Team Session",
+        "description": "Deep-copy a team session into a new independent session. Every run is copied with a fresh ``run_id``; the new session has a fresh ``session_id``. The original is untouched. Use to explore alternative conversation paths without mutating the source.\n\nDistinct from ``/continue?fork=true``: that creates a sibling **run** inside the **same** session. This creates a sibling **session**.",
+        "operationId": "fork_team_session",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Team Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session forked successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Source session is empty or missing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Team not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
             "content": {
               "application/json": {
                 "schema": {
@@ -2287,6 +3183,227 @@
         }
       }
     },
+    "/teams/{team_id}/runs/{run_id}/checkpoints": {
+      "get": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "List Team Run Checkpoints",
+        "description": "List FE-friendly continuation boundaries derived from the current stored team run. No separate checkpoint table is used; entries are inferred from message-level checkpoint markers and the terminal end of the transcript.",
+        "operationId": "list_team_run_checkpoints",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Team Id"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Session ID for the run",
+              "title": "Session Id"
+            },
+            "description": "Session ID for the run"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run checkpoints retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Team or run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/{team_id}/runs/{run_id}/checkpoints/{message_index}": {
+      "get": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "Get Team Run Checkpoint Snapshot",
+        "description": "Return a derived team run snapshot truncated at a message boundary. Use the returned message_index as `continue_from` when continuing this run.",
+        "operationId": "get_team_run_checkpoint_snapshot",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Team Id"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          },
+          {
+            "name": "message_index",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Message Index"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Session ID for the run",
+              "title": "Session Id"
+            },
+            "description": "Session ID for the run"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run checkpoint snapshot retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid checkpoint message index",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Team or run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/workflows": {
       "get": {
         "tags": [
@@ -2398,6 +3515,24 @@
               "type": "string",
               "title": "Workflow Id"
             }
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Workflow version to retrieve",
+              "title": "Version"
+            },
+            "description": "Workflow version to retrieve"
           }
         ],
         "responses": {
@@ -2567,6 +3702,247 @@
             }
           }
         }
+      },
+      "get": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "List Workflow Runs",
+        "description": "List runs for a workflow within a session, optionally filtered by status.\n\nUseful for monitoring background runs and viewing run history.",
+        "operationId": "list_workflow_runs",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Session ID to list runs for",
+              "title": "Session Id"
+            },
+            "description": "Session ID to list runs for"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by run status (PENDING, RUNNING, COMPLETED, ERROR, PAUSED)",
+              "title": "Status"
+            },
+            "description": "Filter by run status (PENDING, RUNNING, COMPLETED, ERROR, PAUSED)"
+          },
+          {
+            "name": "factory_input",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "JSON object with factory-specific parameters for dynamic workflow reconstruction",
+              "title": "Factory Input"
+            },
+            "description": "JSON object with factory-specific parameters for dynamic workflow reconstruction"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of runs retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/workflows/{workflow_id}/runs/{run_id}/continue": {
+      "post": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Continue Workflow Run",
+        "description": "Continue a paused workflow run with resolved requirements.\n\n**Use Cases:**\n- Resume after step-level HITL (confirmation, user input, router selection)\n- Resume after executor-level HITL (agent/team tool confirmation within a step)\n\n**Requirements Parameter:**\nJSON string containing the resolved step requirements.",
+        "operationId": "continue_workflow_run",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_continue_workflow_run"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Workflow run continued successfully",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/event-stream": {
+                "example": "event: StepCompleted\ndata: {\"step_name\": \"step1\"}\n\n"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON in requirements field",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Run is not paused. Only PAUSED runs can be continued."
+          }
+        }
       }
     },
     "/workflows/{workflow_id}/runs/{run_id}/cancel": {
@@ -2600,6 +3976,24 @@
               "type": "string",
               "title": "Run Id"
             }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session ID the run belongs to. Required for non-admin JWT users.",
+              "title": "Session Id"
+            },
+            "description": "Session ID the run belongs to. Required for non-admin JWT users."
           }
         ],
         "responses": {
@@ -2664,6 +4058,111 @@
         }
       }
     },
+    "/workflows/{workflow_id}/runs/{run_id}/resume": {
+      "post": {
+        "tags": [
+          "Workflows"
+        ],
+        "summary": "Resume Workflow Run Stream",
+        "description": "Resume an SSE stream for a workflow run after disconnection.\n\nSends missed events since `last_event_index`, then continues streaming live events if the run is still active.\n\n**Three reconnection paths:**\n1. **Run still active**: Sends catch-up events + continues live streaming\n2. **Run completed (in buffer)**: Replays missed buffered events\n3. **Run completed (in database)**: Replays events from database\n\n**Client usage:**\nTrack `event_index` from each SSE event. On reconnection, pass the last received `event_index` as `last_event_index`.",
+        "operationId": "resume_workflow_run_stream",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "workflow_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workflow Id"
+            }
+          },
+          {
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Run Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_resume_workflow_run_stream"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "SSE stream of catch-up and/or live events",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/event-stream": {}
+            }
+          },
+          "400": {
+            "description": "Not supported for remote workflows",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Workflow not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/workflows/{workflow_id}/runs/{run_id}": {
       "get": {
         "tags": [
@@ -2706,6 +4205,24 @@
               "title": "Session Id"
             },
             "description": "Session ID for the run"
+          },
+          {
+            "name": "factory_input",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "JSON object with factory-specific parameters for dynamic workflow reconstruction",
+              "title": "Factory Input"
+            },
+            "description": "JSON object with factory-specific parameters for dynamic workflow reconstruction"
           }
         ],
         "responses": {
@@ -2770,6 +4287,743 @@
         }
       }
     },
+    "/queue": {
+      "get": {
+        "tags": [
+          "Queue"
+        ],
+        "summary": " Disabled",
+        "operationId": "disabled_queue_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Queue"
+        ],
+        "summary": " Disabled",
+        "operationId": "disabled_queue_put",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Queue"
+        ],
+        "summary": " Disabled",
+        "operationId": "disabled_queue_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Queue"
+        ],
+        "summary": " Disabled",
+        "operationId": "disabled_queue_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Queue"
+        ],
+        "summary": " Disabled",
+        "operationId": "disabled_queue_patch",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/agents/{id}/.well-known/agent-card.json": {
+      "get": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Get Agent Card",
+        "operationId": "get_agent_card_a2a_agents__id___well_known_agent_card_json_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/agents/{id}/v1/message:send": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Run Message Agent",
+        "description": "Send a message to an Agno Agent (non-streaming). The Agent is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata.",
+        "operationId": "run_message_agent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Message sent successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendMessageSuccessResponse"
+                },
+                "example": {
+                  "jsonrpc": "2.0",
+                  "id": "request-123",
+                  "result": {
+                    "task": {
+                      "id": "task-456",
+                      "context_id": "context-789",
+                      "status": "completed",
+                      "history": [
+                        {
+                          "message_id": "msg-1",
+                          "role": "agent",
+                          "parts": [
+                            {
+                              "kind": "text",
+                              "text": "Response from agent"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "404": {
+            "description": "Agent not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/agents/{id}/v1/tasks:get": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Get Agent Task",
+        "description": "Get the status and result of an agent task by ID.",
+        "operationId": "get_agent_task",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/agents/{id}/v1/tasks:cancel": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Cancel Agent Task",
+        "description": "Cancel a running agent task.",
+        "operationId": "cancel_agent_task",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/agents/{id}/v1/message:stream": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Stream Message Agent",
+        "description": "Stream a message to an Agno Agent (streaming). The Agent is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata. Returns real-time updates as newline-delimited JSON (NDJSON).",
+        "operationId": "stream_message_agent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Streaming response with task updates",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/event-stream": {
+                "example": "event: TaskStatusUpdateEvent\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"request-123\",\"result\":{\"taskId\":\"task-456\",\"status\":\"working\"}}\n\nevent: Message\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"request-123\",\"result\":{\"messageId\":\"msg-1\",\"role\":\"agent\",\"parts\":[{\"kind\":\"text\",\"text\":\"Response\"}]}}\n\n"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "404": {
+            "description": "Agent not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/teams/{id}/.well-known/agent-card.json": {
+      "get": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Get Team Card",
+        "operationId": "get_team_card_a2a_teams__id___well_known_agent_card_json_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/teams/{id}/v1/message:send": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Run Message Team",
+        "description": "Send a message to an Agno Team (non-streaming). The Team is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata.",
+        "operationId": "run_message_team",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Message sent successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendMessageSuccessResponse"
+                },
+                "example": {
+                  "jsonrpc": "2.0",
+                  "id": "request-123",
+                  "result": {
+                    "task": {
+                      "id": "task-456",
+                      "context_id": "context-789",
+                      "status": "completed",
+                      "history": [
+                        {
+                          "message_id": "msg-1",
+                          "role": "agent",
+                          "parts": [
+                            {
+                              "kind": "text",
+                              "text": "Response from agent"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/teams/{id}/v1/tasks:get": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Get Team Task",
+        "description": "Get the status and result of a team task by ID.",
+        "operationId": "get_team_task",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/teams/{id}/v1/tasks:cancel": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Cancel Team Task",
+        "description": "Cancel a running team task.",
+        "operationId": "cancel_team_task",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/teams/{id}/v1/message:stream": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Stream Message Team",
+        "description": "Stream a message to an Agno Team (streaming). The Team is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata. Returns real-time updates as newline-delimited JSON (NDJSON).",
+        "operationId": "stream_message_team",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Streaming response with task updates",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/event-stream": {
+                "example": "event: TaskStatusUpdateEvent\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"request-123\",\"result\":{\"taskId\":\"task-456\",\"status\":\"working\"}}\n\nevent: Message\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"request-123\",\"result\":{\"messageId\":\"msg-1\",\"role\":\"agent\",\"parts\":[{\"kind\":\"text\",\"text\":\"Response\"}]}}\n\n"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "404": {
+            "description": "Team not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/workflows/{id}/.well-known/agent-card.json": {
+      "get": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Get Workflow Card",
+        "operationId": "get_workflow_card_a2a_workflows__id___well_known_agent_card_json_get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/workflows/{id}/v1/message:send": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Run Message Workflow",
+        "description": "Send a message to an Agno Workflow (non-streaming). The Workflow is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata.",
+        "operationId": "run_message_workflow",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Message sent successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SendMessageSuccessResponse"
+                },
+                "example": {
+                  "jsonrpc": "2.0",
+                  "id": "request-123",
+                  "result": {
+                    "task": {
+                      "id": "task-456",
+                      "context_id": "context-789",
+                      "status": "completed",
+                      "history": [
+                        {
+                          "message_id": "msg-1",
+                          "role": "agent",
+                          "parts": [
+                            {
+                              "kind": "text",
+                              "text": "Response from agent"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "404": {
+            "description": "Workflow not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/a2a/workflows/{id}/v1/message:stream": {
+      "post": {
+        "tags": [
+          "A2A"
+        ],
+        "summary": "Stream Message Workflow",
+        "description": "Stream a message to an Agno Workflow (streaming). The Workflow is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata. Returns real-time updates as newline-delimited JSON (NDJSON).",
+        "operationId": "stream_message_workflow",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Streaming response with task updates",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "text/event-stream": {
+                "example": "event: TaskStatusUpdateEvent\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"request-123\",\"result\":{\"taskId\":\"task-456\",\"status\":\"working\"}}\n\nevent: Message\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"request-123\",\"result\":{\"messageId\":\"msg-1\",\"role\":\"agent\",\"parts\":[{\"kind\":\"text\",\"text\":\"Response\"}]}}\n\n"
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "404": {
+            "description": "Workflow not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/sessions": {
       "get": {
         "tags": [
@@ -2789,11 +5043,18 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/SessionType",
-              "description": "Type of sessions to retrieve (agent, team, or workflow)",
-              "default": "agent"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SessionType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Type of sessions to retrieve (agent, team, or workflow). If not provided, returns all session types.",
+              "title": "Type"
             },
-            "description": "Type of sessions to retrieve (agent, team, or workflow)"
+            "description": "Type of sessions to retrieve (agent, team, or workflow). If not provided, returns all session types."
           },
           {
             "name": "component_id",
@@ -3188,6 +5449,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "A session with the supplied session_id already exists"
           }
         }
       },
@@ -3257,6 +5521,18 @@
               "title": "Table"
             },
             "description": "Table to use for deletion"
+          },
+          {
+            "name": "delete_media",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Also delete the sessions' offloaded media from media storage",
+              "default": false,
+              "title": "Delete Media"
+            },
+            "description": "Also delete the sessions' offloaded media from media storage"
           }
         ],
         "requestBody": {
@@ -3356,11 +5632,18 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/SessionType",
-              "description": "Session type (agent, team, or workflow)",
-              "default": "agent"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SessionType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data.",
+              "title": "Type"
             },
-            "description": "Session type (agent, team, or workflow)"
+            "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data."
           },
           {
             "name": "user_id",
@@ -3636,6 +5919,18 @@
               "title": "Table"
             },
             "description": "Table to use for deletion"
+          },
+          {
+            "name": "delete_media",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Also delete the session's offloaded media from media storage",
+              "default": false,
+              "title": "Delete Media"
+            },
+            "description": "Also delete the session's offloaded media from media storage"
           }
         ],
         "responses": {
@@ -3723,11 +6018,18 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/SessionType",
-              "description": "Session type (agent, team, or workflow)",
-              "default": "agent"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SessionType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data.",
+              "title": "Type"
             },
-            "description": "Session type (agent, team, or workflow)"
+            "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data."
           },
           {
             "name": "user_id",
@@ -3939,11 +6241,18 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/SessionType",
-              "description": "Session type (agent, team, or workflow)",
-              "default": "agent"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SessionType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data.",
+              "title": "Type"
             },
-            "description": "Session type (agent, team, or workflow)"
+            "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data."
           },
           {
             "name": "user_id",
@@ -4251,11 +6560,18 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/SessionType",
-              "description": "Session type (agent, team, or workflow)",
-              "default": "agent"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SessionType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session type (agent, team, or workflow). If not provided, the run type is inferred from the run's own fields.",
+              "title": "Type"
             },
-            "description": "Session type (agent, team, or workflow)"
+            "description": "Session type (agent, team, or workflow). If not provided, the run type is inferred from the run's own fields."
           },
           {
             "name": "user_id",
@@ -4431,11 +6747,18 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/SessionType",
-              "description": "Session type (agent, team, or workflow)",
-              "default": "agent"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SessionType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data.",
+              "title": "Type"
             },
-            "description": "Session type (agent, team, or workflow)"
+            "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data."
           },
           {
             "name": "user_id",
@@ -4638,6 +6961,184 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{session_id}/media/{storage_key}": {
+      "get": {
+        "tags": [
+          "Media"
+        ],
+        "summary": "Fetch stored media for a session",
+        "description": "Stream (or, with redirect=true, redirect to a freshly-signed URL for) a piece of media stored in external media storage. Scoped to the caller's session ownership; the storage_key must belong to the session.",
+        "operationId": "get_session_media",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Session ID the media belongs to",
+              "title": "Session Id"
+            },
+            "description": "Session ID the media belongs to"
+          },
+          {
+            "name": "storage_key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Storage key of the media to fetch",
+              "title": "Storage Key"
+            },
+            "description": "Storage key of the media to fetch"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SessionType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data.",
+              "title": "Type"
+            },
+            "description": "Session type (agent, team, or workflow). If not provided, auto-detected from session data."
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "User ID to query session from",
+              "title": "User Id"
+            },
+            "description": "User ID to query session from"
+          },
+          {
+            "name": "db_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Database ID to query session from",
+              "title": "Db Id"
+            },
+            "description": "Database ID to query session from"
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Table to query session from",
+              "title": "Table"
+            },
+            "description": "Table to query session from"
+          },
+          {
+            "name": "redirect",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Redirect to a freshly-signed URL instead of streaming bytes",
+              "default": false,
+              "title": "Redirect"
+            },
+            "description": "Redirect to a freshly-signed URL instead of streaming bytes"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The media bytes, served with the stored mime type",
+            "content": {
+              "application/json": {
+                "schema": {}
+              },
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session or media not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Media storage could not be reached"
+          },
+          "501": {
+            "description": "Remote databases are not supported"
+          },
+          "503": {
+            "description": "Media storage is not configured"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -6107,6 +8608,1181 @@
         }
       }
     },
+    "/learnings": {
+      "get": {
+        "tags": [
+          "Learnings"
+        ],
+        "summary": "List Learnings",
+        "description": "List learning records with pagination and optional filters. For a scoped (non-admin) caller with user isolation enabled, results are bound to that user and also include records with no owner (`user_id IS NULL`) \u2014 this covers global, agent, team, session, and entity-scoped learnings; passing a `user_id` that differs from the caller is rejected with 403. Admins and unscoped callers see all records (optionally filtered by `user_id`).",
+        "operationId": "list_learnings",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "learning_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by learning type",
+              "title": "Learning Type"
+            },
+            "description": "Filter by learning type"
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by user ID",
+              "title": "User Id"
+            },
+            "description": "Filter by user ID"
+          },
+          {
+            "name": "agent_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by agent ID",
+              "title": "Agent Id"
+            },
+            "description": "Filter by agent ID"
+          },
+          {
+            "name": "team_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by team ID",
+              "title": "Team Id"
+            },
+            "description": "Filter by team ID"
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by session ID",
+              "title": "Session Id"
+            },
+            "description": "Filter by session ID"
+          },
+          {
+            "name": "namespace",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by namespace",
+              "title": "Namespace"
+            },
+            "description": "Filter by namespace"
+          },
+          {
+            "name": "entity_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by entity ID",
+              "title": "Entity Id"
+            },
+            "description": "Filter by entity ID"
+          },
+          {
+            "name": "entity_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by entity type",
+              "title": "Entity Type"
+            },
+            "description": "Filter by entity type"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Page size",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Page size"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-indexed page number",
+              "default": 1,
+              "title": "Page"
+            },
+            "description": "1-indexed page number"
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Field to sort by, e.g. `created_at` or `updated_at` (the default). An unrecognised field is ignored (the default ordering is used).",
+              "title": "Sort By"
+            },
+            "description": "Field to sort by, e.g. `created_at` or `updated_at` (the default). An unrecognised field is ignored (the default ordering is used)."
+          },
+          {
+            "name": "sort_order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SortOrder"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Sort order (asc or desc)",
+              "default": "desc",
+              "title": "Sort Order"
+            },
+            "description": "Sort order (asc or desc)"
+          },
+          {
+            "name": "db_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Database ID to query",
+              "title": "Db Id"
+            },
+            "description": "Database ID to query"
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The database table to use (requires db_id)",
+              "title": "Table"
+            },
+            "description": "The database table to use (requires db_id)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_LearningResponse_"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Learnings"
+        ],
+        "summary": "Create Learning",
+        "description": "Create a new learning record. For the identity-keyed learning types (`user_profile`, `user_memory`, `session_context`, `entity_memory`) the record id is derived deterministically from the identity fields so it reconciles with what the agent reads/writes \u2014 provide those fields (else 422), and if a record already exists the request is rejected with 409 (use PATCH to update it). Other types get a generated id. For a scoped (non-admin) caller, the body's `user_id` must be omitted/null or match the caller (mismatch \u2192 403); admins and unscoped callers may set any `user_id`. An `entity_memory` record whose body omits `namespace` is stored under the `global` default; the endpoint cannot see how a given store is configured, so a caller writing for a store running with `namespace=\"user\"` or a custom namespace must pass `namespace` explicitly or the record will not be visible to it.",
+        "operationId": "create_learning",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "db_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Database ID to use",
+              "title": "Db Id"
+            },
+            "description": "Database ID to use"
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The database table to use (requires db_id)",
+              "title": "Table"
+            },
+            "description": "The database table to use (requires db_id)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LearningCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LearningResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/learnings/users": {
+      "get": {
+        "tags": [
+          "Learnings"
+        ],
+        "summary": "List Learning Users",
+        "description": "List the users that own learning records, with a per-user count and last-updated timestamp. Intended as the entry point for a per-user view: list users here, then drill into a single user's learnings via `GET /learnings?user_id=...`. Records with no owner (`user_id IS NULL`) are excluded. Pass `learning_type` to restrict the grouping to a single store (e.g. `user_profile` or `user_memory`). For a scoped (non-admin) caller results are bound to that user; an explicit `user_id` that differs is rejected with 403. Admins and unscoped callers list all users. Sortable by `user_id` or `last_learning_updated_at` (the default).",
+        "operationId": "list_learning_users",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "learning_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict the grouping to a single learning type",
+              "title": "Learning Type"
+            },
+            "description": "Restrict the grouping to a single learning type"
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict the result to a single user",
+              "title": "User Id"
+            },
+            "description": "Restrict the result to a single user"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Page size",
+              "default": 20,
+              "title": "Limit"
+            },
+            "description": "Page size"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "1-indexed page number",
+              "default": 1,
+              "title": "Page"
+            },
+            "description": "1-indexed page number"
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Field to sort by: user_id or last_learning_updated_at (the default)",
+              "title": "Sort By"
+            },
+            "description": "Field to sort by: user_id or last_learning_updated_at (the default)"
+          },
+          {
+            "name": "sort_order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/SortOrder"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Sort order (asc or desc)",
+              "default": "desc",
+              "title": "Sort Order"
+            },
+            "description": "Sort order (asc or desc)"
+          },
+          {
+            "name": "db_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Database ID to query",
+              "title": "Db Id"
+            },
+            "description": "Database ID to query"
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The database table to use (requires db_id)",
+              "title": "Table"
+            },
+            "description": "The database table to use (requires db_id)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_LearningUserStats_"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/learnings/users/{user_id}": {
+      "delete": {
+        "tags": [
+          "Learnings"
+        ],
+        "summary": "Delete Learning User",
+        "description": "Delete the learning records owned by a user. By default removes every learning type backed by the agno_learnings table (user_profile, user_memory, and any user-scoped entity records); pass `learning_type` to restrict deletion to a single store. Records with no owner (`user_id IS NULL`) are not affected. For a scoped (non-admin) caller, only their own learnings may be deleted; a different `user_id` is rejected with 403. Admins and unscoped callers may delete any user's learnings. Returns 204 even if the user had no matching records.",
+        "operationId": "delete_learning_user",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The user whose learnings should be deleted",
+              "title": "User Id"
+            },
+            "description": "The user whose learnings should be deleted"
+          },
+          {
+            "name": "learning_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Restrict deletion to a single learning type; omit to delete all of the user's learnings",
+              "title": "Learning Type"
+            },
+            "description": "Restrict deletion to a single learning type; omit to delete all of the user's learnings"
+          },
+          {
+            "name": "db_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Database ID to use",
+              "title": "Db Id"
+            },
+            "description": "Database ID to use"
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The database table to use (requires db_id)",
+              "title": "Table"
+            },
+            "description": "The database table to use (requires db_id)"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/learnings/{learning_id}": {
+      "get": {
+        "tags": [
+          "Learnings"
+        ],
+        "summary": "Get Learning",
+        "description": "Retrieve a single learning record by its ID.",
+        "operationId": "get_learning",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "learning_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The learning ID",
+              "title": "Learning Id"
+            },
+            "description": "The learning ID"
+          },
+          {
+            "name": "db_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Database ID to query",
+              "title": "Db Id"
+            },
+            "description": "Database ID to query"
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The database table to use (requires db_id)",
+              "title": "Table"
+            },
+            "description": "The database table to use (requires db_id)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LearningResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Learnings"
+        ],
+        "summary": "Update Learning",
+        "description": "Update a learning record. Only `content` and `metadata` may be modified; identity fields (user_id, agent_id, team_id, etc.) are immutable. Provided fields fully replace the existing values. Records with no owner (`user_id IS NULL` \u2014 shared agent/team/session/entity learnings) are readable by any caller but may only be modified by an admin.",
+        "operationId": "update_learning",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "learning_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The learning ID",
+              "title": "Learning Id"
+            },
+            "description": "The learning ID"
+          },
+          {
+            "name": "db_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Database ID to use",
+              "title": "Db Id"
+            },
+            "description": "Database ID to use"
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The database table to use (requires db_id)",
+              "title": "Table"
+            },
+            "description": "The database table to use (requires db_id)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LearningUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LearningResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Learnings"
+        ],
+        "summary": "Delete Learning",
+        "description": "Permanently delete a learning record by its ID. Records with no owner (`user_id IS NULL` \u2014 shared agent/team/session/entity learnings) may only be deleted by an admin.",
+        "operationId": "delete_learning",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "learning_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "The learning ID",
+              "title": "Learning Id"
+            },
+            "description": "The learning ID"
+          },
+          {
+            "name": "db_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Database ID to use",
+              "title": "Db Id"
+            },
+            "description": "Database ID to use"
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The database table to use (requires db_id)",
+              "title": "Table"
+            },
+            "description": "The database table to use (requires db_id)"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/eval-runs": {
       "get": {
         "tags": [
@@ -7045,6 +10721,24 @@
             "description": "Ending date for metrics range (YYYY-MM-DD format)"
           },
           {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only this user's metrics. Ignored for non-admin callers",
+              "title": "User Id"
+            },
+            "description": "Return only this user's metrics. Ignored for non-admin callers"
+          },
+          {
             "name": "db_id",
             "in": "query",
             "required": false,
@@ -7092,7 +10786,7 @@
                 "example": {
                   "metrics": [
                     {
-                      "id": "7bf39658-a00a-484c-8a28-67fd8a9ddb2a",
+                      "id": "2025-07-31_daily",
                       "agent_runs_count": 5,
                       "agent_sessions_count": 5,
                       "team_runs_count": 0,
@@ -7186,7 +10880,7 @@
           "Metrics"
         ],
         "summary": "Refresh Metrics",
-        "description": "Manually trigger recalculation of system metrics from raw data. This operation analyzes system activity logs and regenerates aggregated metrics. Useful for ensuring metrics are up-to-date or after system maintenance.",
+        "description": "Manually trigger recalculation of system metrics from raw data. This operation analyzes system activity logs and regenerates aggregated metrics. Useful for ensuring metrics are up-to-date or after system maintenance. By default the refresh runs synchronously and returns the refreshed metrics. Pass background=true to run the refresh in the background instead: the endpoint returns 202 Accepted immediately and GET /metrics can be polled for results. If a background refresh is already in progress for the target database, returns status 'already_running' without starting a new one.",
         "operationId": "refresh_metrics",
         "security": [
           {
@@ -7229,6 +10923,36 @@
               "title": "Table"
             },
             "description": "Table to use for metrics calculation"
+          },
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Return only this user's metrics. Ignored for non-admin callers",
+              "title": "User Id"
+            },
+            "description": "Return only this user's metrics. Ignored for non-admin callers"
+          },
+          {
+            "name": "background",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Run the refresh in the background and return 202 immediately",
+              "default": false,
+              "title": "Background"
+            },
+            "description": "Run the refresh in the background and return 202 immediately"
           }
         ],
         "responses": {
@@ -7237,15 +10961,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DayAggregatedMetrics"
-                  },
+                  "anyOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/DayAggregatedMetrics"
+                      }
+                    },
+                    {
+                      "$ref": "#/components/schemas/MetricsRefreshResponse"
+                    }
+                  ],
                   "title": "Response Refresh Metrics"
                 },
                 "example": [
                   {
-                    "id": "e77c9531-818b-47a5-99cd-59fed61e5403",
+                    "id": "2025-08-12_daily",
                     "agent_runs_count": 2,
                     "agent_sessions_count": 2,
                     "team_runs_count": 0,
@@ -7256,17 +10987,11 @@
                     "token_metrics": {
                       "input_tokens": 256,
                       "output_tokens": 441,
-                      "total_tokens": 697,
-                      "audio_total_tokens": 0,
-                      "audio_input_tokens": 0,
-                      "audio_output_tokens": 0,
-                      "cache_read_tokens": 0,
-                      "cache_write_tokens": 0,
-                      "reasoning_tokens": 0
+                      "total_tokens": 697
                     },
                     "model_metrics": [
                       {
-                        "model_id": "gpt-4o",
+                        "model_id": "gpt-5.5",
                         "model_provider": "OpenAI",
                         "count": 2
                       }
@@ -7321,6 +11046,137 @@
           },
           "500": {
             "description": "Failed to refresh metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Background refresh started",
+            "content": {
+              "application/json": {
+                "example": {
+                  "status": "started",
+                  "message": "Metrics refresh started in background"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metrics/refresh/status": {
+      "get": {
+        "tags": [
+          "Metrics"
+        ],
+        "summary": "Get Metrics Refresh Status",
+        "description": "Get the status of the most recent metrics refresh for the target database. Returns 'running' while a refresh is in progress, then 'completed' or 'failed' with the finish timestamp \u2014 the state updates even when a refresh completes without writing new data. Returns 'idle' if no refresh has been triggered since this server process started. For remote databases the status is fetched from the remote AgentOS. Intended for polling after starting a background refresh via POST /metrics/refresh?background=true.",
+        "operationId": "get_metrics_refresh_status",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "db_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Database ID to get the refresh status for",
+              "title": "Db Id"
+            },
+            "description": "Database ID to get the refresh status for"
+          },
+          {
+            "name": "table",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Table to get the refresh status for",
+              "title": "Table"
+            },
+            "description": "Table to get the refresh status for"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current refresh status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricsRefreshStatusResponse"
+                },
+                "example": {
+                  "status": "completed",
+                  "started_at": "2025-08-12T08:01:47Z",
+                  "finished_at": "2025-08-12T08:01:49Z"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Database not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to get refresh status",
             "content": {
               "application/json": {
                 "schema": {
@@ -7462,6 +11318,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       },
@@ -7676,6 +11535,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       },
@@ -7787,6 +11649,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       }
@@ -7921,6 +11786,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       }
@@ -8069,6 +11937,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       },
@@ -8204,6 +12075,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       },
@@ -8326,6 +12200,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       }
@@ -8459,6 +12336,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       }
@@ -8551,6 +12431,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         },
         "security": [
@@ -8693,6 +12576,19 @@
                         "RecursiveChunker"
                       ]
                     },
+                    "docling": {
+                      "id": "docling",
+                      "name": "DoclingReader",
+                      "description": "Converts multiple document formats like PDF, DOCX, PPTX, images, HTML, etc. using IBM's Docling library",
+                      "chunkers": [
+                        "AgenticChunker",
+                        "CodeChunker",
+                        "DocumentChunker",
+                        "FixedSizeChunker",
+                        "RecursiveChunker",
+                        "SemanticChunker"
+                      ]
+                    },
                     "docx": {
                       "id": "docx",
                       "name": "DocxReader",
@@ -8792,10 +12688,12 @@
                     ],
                     ".csv": [
                       "csv",
-                      "field_labeled_csv"
+                      "field_labeled_csv",
+                      "docling"
                     ],
                     ".xlsx": [
-                      "excel"
+                      "excel",
+                      "docling"
                     ],
                     ".xls": [
                       "excel"
@@ -8807,22 +12705,140 @@
                       "excel"
                     ],
                     ".docx": [
-                      "docx"
+                      "docx",
+                      "docling"
                     ],
-                    ".doc": [
-                      "docx"
+                    ".dotx": [
+                      "docling"
+                    ],
+                    ".docm": [
+                      "docling"
+                    ],
+                    ".dotm": [
+                      "docling"
+                    ],
+                    ".pptx": [
+                      "docling",
+                      "pptx"
+                    ],
+                    ".potx": [
+                      "docling"
+                    ],
+                    ".ppsx": [
+                      "docling"
+                    ],
+                    ".pptm": [
+                      "docling"
+                    ],
+                    ".ppsm": [
+                      "docling"
+                    ],
+                    ".potm": [
+                      "docling"
                     ],
                     ".json": [
                       "json"
                     ],
                     ".md": [
-                      "markdown"
+                      "markdown",
+                      "docling"
                     ],
                     ".pdf": [
-                      "pdf"
+                      "pdf",
+                      "docling"
                     ],
                     ".txt": [
                       "text"
+                    ],
+                    ".html": [
+                      "docling"
+                    ],
+                    ".htm": [
+                      "docling"
+                    ],
+                    ".xhtml": [
+                      "docling"
+                    ],
+                    ".xml": [
+                      "docling"
+                    ],
+                    ".nxml": [
+                      "docling"
+                    ],
+                    ".xbrl": [
+                      "docling"
+                    ],
+                    ".adoc": [
+                      "docling"
+                    ],
+                    ".asciidoc": [
+                      "docling"
+                    ],
+                    ".asc": [
+                      "docling"
+                    ],
+                    ".xlsm": [
+                      "docling"
+                    ],
+                    ".tex": [
+                      "docling"
+                    ],
+                    ".latex": [
+                      "docling"
+                    ],
+                    ".tar.gz": [
+                      "docling"
+                    ],
+                    ".vtt": [
+                      "docling"
+                    ],
+                    ".png": [
+                      "docling"
+                    ],
+                    ".jpeg": [
+                      "docling"
+                    ],
+                    ".jpg": [
+                      "docling"
+                    ],
+                    ".tiff": [
+                      "docling"
+                    ],
+                    ".tif": [
+                      "docling"
+                    ],
+                    ".bmp": [
+                      "docling"
+                    ],
+                    ".webp": [
+                      "docling"
+                    ],
+                    ".wav": [
+                      "docling"
+                    ],
+                    ".mp3": [
+                      "docling"
+                    ],
+                    ".m4a": [
+                      "docling"
+                    ],
+                    ".aac": [
+                      "docling"
+                    ],
+                    ".ogg": [
+                      "docling"
+                    ],
+                    ".flac": [
+                      "docling"
+                    ],
+                    ".mp4": [
+                      "docling"
+                    ],
+                    ".avi": [
+                      "docling"
+                    ],
+                    ".mov": [
+                      "docling"
                     ]
                   },
                   "chunkers": {
@@ -8962,6 +12978,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       }
@@ -9082,6 +13101,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       }
@@ -9285,6 +13307,9 @@
                 }
               }
             }
+          },
+          "503": {
+            "description": "No knowledge base is configured on this AgentOS"
           }
         }
       }
@@ -10500,6 +14525,18 @@
               "title": "Limit"
             },
             "description": "Items per page"
+          },
+          {
+            "name": "include_deleted",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Also list archived (soft-deleted) components, marked by a deleted_at timestamp",
+              "default": false,
+              "title": "Include Deleted"
+            },
+            "description": "Also list archived (soft-deleted) components, marked by a deleted_at timestamp"
           }
         ],
         "responses": {
@@ -10675,6 +14712,18 @@
               "title": "Component Id"
             },
             "description": "Component ID"
+          },
+          {
+            "name": "include_deleted",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Also return an archived (soft-deleted) component, marked by a deleted_at timestamp",
+              "default": false,
+              "title": "Include Deleted"
+            },
+            "description": "Also return an archived (soft-deleted) component, marked by a deleted_at timestamp"
           }
         ],
         "responses": {
@@ -10862,11 +14911,137 @@
               "title": "Component Id"
             },
             "description": "Component ID"
+          },
+          {
+            "name": "expected_current_version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional compare-and-set guard on the current version",
+              "title": "Expected Current Version"
+            },
+            "description": "Optional compare-and-set guard on the current version"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ComponentDeleteRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Optional compare-and-set guard, matching the other guarded routes",
+                "title": "Body"
+              }
+            }
+          }
+        },
         "responses": {
           "204": {
             "description": "Successful Response"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthenticatedResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/components/{component_id}/restore": {
+      "post": {
+        "tags": [
+          "Components"
+        ],
+        "summary": "Restore Component",
+        "description": "Restore an archived (soft-deleted) component by ID.",
+        "operationId": "restore_component",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "component_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Component ID",
+              "title": "Component Id"
+            },
+            "description": "Component ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComponentResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request",
@@ -11556,6 +15731,24 @@
             "description": "Version number"
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/SetCurrentRequest"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Optional guard; an empty POST keeps working",
+                "title": "Body"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -12623,6 +16816,184 @@
         }
       }
     },
+    "/service-accounts": {
+      "post": {
+        "tags": [
+          "Service Accounts"
+        ],
+        "summary": "Create Service Account",
+        "description": "Mint a service account token. The plaintext token is returned exactly once.",
+        "operationId": "create_service_account_service_accounts_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ServiceAccountCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceAccountCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Service Accounts"
+        ],
+        "summary": "List Service Accounts",
+        "description": "List service accounts. Returns metadata and display prefixes only - never hashes or plaintext.",
+        "operationId": "list_service_accounts_service_accounts_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "include_revoked",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true,
+              "title": "Include Revoked"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 20,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "created_at",
+              "title": "Sort By"
+            }
+          },
+          {
+            "name": "sort_order",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "title": "Sort Order"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_ServiceAccountResponse_"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service-accounts/{service_account_id}": {
+      "delete": {
+        "tags": [
+          "Service Accounts"
+        ],
+        "summary": "Revoke Service Account",
+        "description": "Revoke a service account. Idempotent.\n\nTakes effect immediately on this worker (the local verification cache entry is\nevicted) and within the cache TTL on other workers.",
+        "operationId": "revoke_service_account_service_accounts__service_account_id__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "service_account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Service Account Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/registry": {
       "get": {
         "tags": [
@@ -12764,6 +17135,153 @@
           }
         }
       }
+    },
+    "/models": {
+      "get": {
+        "tags": [
+          "Core"
+        ],
+        "summary": "Get Available Models",
+        "description": "Retrieve every unique model this OS instance can run: models used by agents and teams (team members included) plus the configured model catalog.",
+        "operationId": "get_models",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Model"
+                  },
+                  "type": "array",
+                  "title": "Response Get Models"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/agents/{agent_id}/model": {
+      "patch": {
+        "tags": [
+          "Core"
+        ],
+        "summary": "Set Agent Model",
+        "description": "Switch a code-defined agent's model at runtime. Takes effect on the next run; does not persist across restarts.",
+        "operationId": "set_agent_model",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Agent Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetAgentModelRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetModelResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/teams/{team_id}/model": {
+      "patch": {
+        "tags": [
+          "Core"
+        ],
+        "summary": "Set Team Model",
+        "description": "Switch a team leader's model at runtime, or a member's via member_id. Takes effect on the next run; does not persist across restarts.",
+        "operationId": "set_team_model",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "team_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Team Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetTeamModelRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetModelResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -12803,6 +17321,17 @@
           "is_active": {
             "type": "boolean",
             "title": "Is Active"
+          },
+          "memory_namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Namespace"
           },
           "created_at": {
             "title": "Created At"
@@ -12907,6 +17436,11 @@
               }
             ],
             "title": "Role"
+          },
+          "is_factory": {
+            "type": "boolean",
+            "title": "Is Factory",
+            "default": false
           },
           "model": {
             "anyOf": [
@@ -13072,6 +17606,18 @@
               }
             ],
             "title": "Input Schema"
+          },
+          "factory_input_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Input Schema"
           },
           "is_component": {
             "type": "boolean",
@@ -13322,10 +17868,246 @@
             ],
             "title": "Db Id",
             "description": "Database identifier"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Model"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Model used by the agent"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "Additional metadata"
           }
         },
         "type": "object",
         "title": "AgentSummaryResponse"
+      },
+      "ApplyAgentRequest": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind",
+            "default": "Agent"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "db": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Db"
+          },
+          "knowledge": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Knowledge"
+          },
+          "stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stage"
+          },
+          "instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instructions"
+          },
+          "toolsets": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Toolsets"
+          },
+          "ibmiTools": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ibmitools"
+          },
+          "options": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Options"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "mode": {
+            "type": "string",
+            "title": "Mode",
+            "default": "apply"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "ApplyAgentRequest",
+        "description": "Friendly agent manifest. All fields optional so a sparse ``update`` can\nuse ``model_fields_set`` to touch only what the caller provided.\n\n``extra=\"forbid\"`` so an unknown/typo'd key (e.g. ``instructionz``) is\nrejected with a 422 rather than silently dropped \u2014 the CLI catches this\nclient-side first, this guards every other caller."
+      },
+      "ApplyAgentResponse": {
+        "properties": {
+          "component_id": {
+            "type": "string",
+            "title": "Component Id"
+          },
+          "stage": {
+            "type": "string",
+            "title": "Stage"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version"
+          },
+          "action": {
+            "type": "string",
+            "title": "Action"
+          },
+          "config_keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Config Keys"
+          },
+          "stripped_overrides": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Stripped Overrides"
+          },
+          "tools_written": {
+            "type": "integer",
+            "title": "Tools Written",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": [
+          "component_id",
+          "stage",
+          "action"
+        ],
+        "title": "ApplyAgentResponse"
       },
       "ApprovalCountResponse": {
         "properties": {
@@ -13686,14 +18468,13 @@
         "title": "ApprovalStatusResponse",
         "description": "Lightweight response model for polling approval status."
       },
-      "BadRequestResponse": {
+      "Artifact": {
         "properties": {
-          "detail": {
+          "artifactId": {
             "type": "string",
-            "title": "Detail",
-            "description": "Error detail message"
+            "title": "Artifactid"
           },
-          "error_code": {
+          "description": {
             "anyOf": [
               {
                 "type": "string"
@@ -13702,8 +18483,91 @@
                 "type": "null"
               }
             ],
-            "title": "Error Code",
-            "description": "Error code for categorization"
+            "title": "Description"
+          },
+          "extensions": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extensions"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "parts": {
+            "items": {
+              "$ref": "#/components/schemas/Part"
+            },
+            "type": "array",
+            "title": "Parts"
+          }
+        },
+        "type": "object",
+        "required": [
+          "artifactId",
+          "parts"
+        ],
+        "title": "Artifact",
+        "description": "Represents a file, data structure, or other resource generated by an agent during a task."
+      },
+      "BadRequestResponse": {
+        "properties": {
+          "detail": {
+            "type": "string",
+            "title": "Detail",
+            "description": "Human-readable error message"
+          },
+          "error_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Id",
+            "description": "Stable identifier for the specific error, present only when the error carries one"
+          },
+          "error_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Type",
+            "description": "Category of the error, present only when the error carries one"
           }
         },
         "type": "object",
@@ -13712,8 +18576,7 @@
         ],
         "title": "BadRequestResponse",
         "example": {
-          "detail": "Bad request",
-          "error_code": "BAD_REQUEST"
+          "detail": "Bad request"
         }
       },
       "Body_continue_agent_run": {
@@ -13722,6 +18585,200 @@
             "type": "string",
             "title": "Tools",
             "description": "JSON string of tool call results to continue the paused run",
+            "default": ""
+          },
+          "input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input",
+            "description": "Optional new user-message text to append to the run before resuming. Use for continuing a COMPLETED run with a follow-up, or adding context to a RUNNING/ERROR resume."
+          },
+          "continue_from": {
+            "type": "string",
+            "title": "Continue From",
+            "description": "Continuation boundary. Use 'end', 'last_user', or a numeric message index.",
+            "default": "end"
+          },
+          "fork": {
+            "type": "boolean",
+            "title": "Fork",
+            "description": "When true, clone the run with a new ``run_id`` before resuming. The original is untouched; the clone becomes a sibling within the same session, with ``forked_from_run_id`` set.",
+            "default": false
+          },
+          "regenerate": {
+            "type": "boolean",
+            "title": "Regenerate",
+            "description": "Sugar: regenerate the last response of this run. Auto-computes ``continue_from='last_user'`` to land just after the last user message. Pair with ``additional_instructions`` to steer the new output. By default the original response is hidden from history (replaced); pass ``replace_original=false`` to keep both the original and the regenerated response visible side by side.",
+            "default": false
+          },
+          "replace_original": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Replace Original",
+            "description": "Only valid with ``regenerate=true``. Controls history visibility of the original response; the original run is always retained in storage. Defaults to true: the original is marked REGENERATED and hidden from history so the new response replaces it. Pass false to keep both the original and regenerated responses visible."
+          },
+          "additional_instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Additional Instructions",
+            "description": "Only valid with ``regenerate=true``: extra guidance appended as a user message before re-generation. Friendly alias for ``input``."
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id",
+            "description": "Session ID for the paused run"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id",
+            "description": "User identifier for tracking and personalization"
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "description": "Enable streaming responses via Server-Sent Events (SSE)",
+            "default": true
+          },
+          "background": {
+            "type": "boolean",
+            "title": "Background",
+            "description": "Run continue in background (survives client disconnect). Requires database. Use /resume to reconnect.",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "Body_continue_agent_run"
+      },
+      "Body_continue_team_run": {
+        "properties": {
+          "requirements": {
+            "type": "string",
+            "title": "Requirements",
+            "default": ""
+          },
+          "input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input"
+          },
+          "continue_from": {
+            "type": "string",
+            "title": "Continue From",
+            "description": "Continuation boundary. Use 'end', 'last_user', or a numeric message index.",
+            "default": "end"
+          },
+          "fork": {
+            "type": "boolean",
+            "title": "Fork",
+            "default": false
+          },
+          "regenerate": {
+            "type": "boolean",
+            "title": "Regenerate",
+            "default": false
+          },
+          "replace_original": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Replace Original"
+          },
+          "additional_instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Additional Instructions"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "default": true
+          },
+          "background": {
+            "type": "boolean",
+            "title": "Background",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "Body_continue_team_run"
+      },
+      "Body_continue_workflow_run": {
+        "properties": {
+          "step_requirements": {
+            "type": "string",
+            "title": "Step Requirements",
+            "description": "JSON string of step requirement objects with resolution status",
             "default": ""
           },
           "session_id": {
@@ -13753,10 +18810,28 @@
             "title": "Stream",
             "description": "Enable streaming responses via Server-Sent Events (SSE)",
             "default": true
+          },
+          "background": {
+            "type": "boolean",
+            "title": "Background",
+            "description": "Continue in background (survives client disconnect). Requires database. Use /resume to reconnect.",
+            "default": false
+          },
+          "factory_input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Input",
+            "description": "JSON object with factory-specific parameters for dynamic workflow reconstruction"
           }
         },
         "type": "object",
-        "title": "Body_continue_agent_run"
+        "title": "Body_continue_workflow_run"
       },
       "Body_create_agent_run": {
         "properties": {
@@ -13800,7 +18875,7 @@
               {
                 "items": {
                   "type": "string",
-                  "format": "binary"
+                  "contentMediaType": "application/octet-stream"
                 },
                 "type": "array"
               },
@@ -13811,10 +18886,22 @@
             "title": "Files",
             "description": "Files to upload (images, audio, video, or documents)"
           },
-          "version": {
+          "files_metadata": {
             "anyOf": [
               {
                 "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Files Metadata",
+            "description": "JSON array of per-file metadata objects, matched to files[] by position"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "integer"
               },
               {
                 "type": "null"
@@ -13828,6 +18915,18 @@
             "title": "Background",
             "description": "Run in background and return immediately with run metadata (requires database)",
             "default": false
+          },
+          "factory_input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Input",
+            "description": "JSON object with factory-specific parameters for dynamic agent construction"
           }
         },
         "type": "object",
@@ -13884,7 +18983,7 @@
               {
                 "items": {
                   "type": "string",
-                  "format": "binary"
+                  "contentMediaType": "application/octet-stream"
                 },
                 "type": "array"
               },
@@ -13894,6 +18993,18 @@
             ],
             "title": "Files",
             "description": "Files to upload (images, audio, video, or documents)"
+          },
+          "files_metadata": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Files Metadata",
+            "description": "JSON array of per-file metadata objects, matched to files[] by position"
           },
           "version": {
             "anyOf": [
@@ -13912,6 +19023,18 @@
             "title": "Background",
             "description": "Run in background and return immediately with run metadata (requires database)",
             "default": false
+          },
+          "factory_input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Input",
+            "description": "JSON object with factory-specific parameters for dynamic team construction"
           }
         },
         "type": "object",
@@ -13932,6 +19055,12 @@
             "title": "Stream",
             "description": "Enable streaming responses via Server-Sent Events (SSE)",
             "default": true
+          },
+          "background": {
+            "type": "boolean",
+            "title": "Background",
+            "description": "Run workflow in background (survives client disconnect). Requires database. Use /resume to reconnect.",
+            "default": false
           },
           "session_id": {
             "anyOf": [
@@ -13968,6 +19097,18 @@
             ],
             "title": "Version",
             "description": "Workflow version to use for this run"
+          },
+          "factory_input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Input",
+            "description": "JSON object with factory-specific parameters for dynamic workflow construction"
           }
         },
         "type": "object",
@@ -13989,6 +19130,96 @@
           "session_name"
         ],
         "title": "Body_rename_session"
+      },
+      "Body_resume_agent_run_stream": {
+        "properties": {
+          "last_event_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event Index",
+            "description": "Index of last event received by client (0-based)"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id",
+            "description": "Session ID for database fallback"
+          }
+        },
+        "type": "object",
+        "title": "Body_resume_agent_run_stream"
+      },
+      "Body_resume_team_run_stream": {
+        "properties": {
+          "last_event_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event Index",
+            "description": "Index of last event received by client (0-based)"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id",
+            "description": "Session ID for database fallback"
+          }
+        },
+        "type": "object",
+        "title": "Body_resume_team_run_stream"
+      },
+      "Body_resume_workflow_run_stream": {
+        "properties": {
+          "last_event_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event Index",
+            "description": "Index of last event received by client (0-based)"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id",
+            "description": "Session ID for database fallback"
+          }
+        },
+        "type": "object",
+        "title": "Body_resume_workflow_run_stream"
       },
       "Body_update_content": {
         "properties": {
@@ -14098,7 +19329,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "format": "binary"
+                "contentMediaType": "application/octet-stream"
               },
               {
                 "type": "null"
@@ -14182,6 +19413,18 @@
             "type": "string",
             "title": "Path",
             "description": "Path to file or folder in the remote source"
+          },
+          "source_params": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Params",
+            "description": "JSON object of per-request parameters forwarded to the source's factory. Used for provider-specific routing that shouldn't be baked into the config. Currently supported keys: GitHub accepts 'repo' ('owner/repo'), letting one configured GitHub source serve multiple repositories the credentials can access."
           },
           "name": {
             "anyOf": [
@@ -14514,6 +19757,55 @@
         ],
         "title": "ComponentCreate"
       },
+      "ComponentDeleteRequest": {
+        "properties": {
+          "guard": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ComponentGuard"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional compare-and-set guard"
+          }
+        },
+        "type": "object",
+        "title": "ComponentDeleteRequest",
+        "description": "Body for delete. Optional: a bodyless DELETE keeps working.\n\nDelete also accepts the guard as an ``expected_current_version`` query\nparam; this shape exists so the guard reads the same as on every other\nguarded component route instead of being silently ignored here."
+      },
+      "ComponentGuard": {
+        "properties": {
+          "latest_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Version",
+            "description": "Expected latest config version"
+          },
+          "current_version": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Version",
+            "description": "Expected current (published) version; 0 expects the component to have none yet"
+          }
+        },
+        "type": "object",
+        "title": "ComponentGuard",
+        "description": "Optional compare-and-set guard for component writes.\n\nWhen present, each non-None field is checked against the stored state and\nthe write is rejected with 409 on mismatch. None fields skip that half of\nthe check; omitting the guard keeps the write last-writer-wins."
+      },
       "ComponentResponse": {
         "properties": {
           "component_id": {
@@ -14533,6 +19825,17 @@
               }
             ],
             "title": "Name"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
           },
           "description": {
             "anyOf": [
@@ -14582,6 +19885,17 @@
               }
             ],
             "title": "Updated At"
+          },
+          "deleted_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deleted At"
           }
         },
         "type": "object",
@@ -14658,6 +19972,16 @@
               }
             ],
             "title": "Current Version"
+          },
+          "guard": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ComponentGuard"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -14734,6 +20058,17 @@
             "title": "Set Current",
             "description": "Set as current version",
             "default": true
+          },
+          "guard": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ComponentGuard"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional compare-and-set guard"
           }
         },
         "type": "object",
@@ -14774,19 +20109,12 @@
             "description": "Description of the OS instance"
           },
           "available_models": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "items": {
+              "$ref": "#/components/schemas/Model"
+            },
+            "type": "array",
             "title": "Available Models",
-            "description": "List of available models"
+            "description": "Unique models (id + provider) in use by agents and teams in this OS"
           },
           "os_database": {
             "anyOf": [
@@ -14818,6 +20146,21 @@
               }
             ],
             "description": "Chat configuration"
+          },
+          "manifest": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/Manifest"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manifest",
+            "description": "Per-entity UI metadata keyed by agent/team/workflow id"
           },
           "session": {
             "anyOf": [
@@ -14851,6 +20194,17 @@
               }
             ],
             "description": "Memory configuration"
+          },
+          "learning": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LearningConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Learning configuration"
           },
           "knowledge": {
             "anyOf": [
@@ -15024,6 +20378,36 @@
             ],
             "title": "Remote Content Sources",
             "description": "Configured remote content sources (S3, GCS, SharePoint, GitHub)"
+          },
+          "unavailable_readers": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/UnavailableReaderSchema"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unavailable Readers",
+            "description": "Readers that are not usable in this install, and the packages they need"
+          },
+          "unavailable_chunkers": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/UnavailableChunkerSchema"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unavailable Chunkers",
+            "description": "Chunking strategies that are not usable in this install, and the packages they need"
           }
         },
         "type": "object",
@@ -15090,6 +20474,16 @@
               }
             ],
             "title": "Links"
+          },
+          "guard": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ComponentGuard"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -15130,6 +20524,17 @@
           "is_active": {
             "type": "boolean",
             "title": "Is Active"
+          },
+          "memory_namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Namespace"
           },
           "created_at": {
             "title": "Created At"
@@ -15401,6 +20806,19 @@
             "title": "Is Default",
             "description": "Set as the default connection for this API key",
             "default": false
+          },
+          "memory_namespace": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Namespace",
+            "description": "Optional memory/learning namespace. Omit for per-system isolation (the default); set the same value on two connections to share a brain across them."
           }
         },
         "type": "object",
@@ -15650,6 +21068,39 @@
         "type": "object",
         "title": "CreateSessionRequest"
       },
+      "DataPart": {
+        "properties": {
+          "data": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Data"
+          },
+          "kind": {
+            "type": "string",
+            "const": "data",
+            "title": "Kind",
+            "default": "data"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "title": "DataPart",
+        "description": "Represents a structured data segment (e.g., JSON) within a message or artifact."
+      },
       "DatabaseConfig_EvalsDomainConfig_": {
         "properties": {
           "db_id": {
@@ -15686,6 +21137,43 @@
           "db_id"
         ],
         "title": "DatabaseConfig[EvalsDomainConfig]"
+      },
+      "DatabaseConfig_LearningDomainConfig_": {
+        "properties": {
+          "db_id": {
+            "type": "string",
+            "title": "Db Id"
+          },
+          "domain_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LearningDomainConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tables": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tables"
+          }
+        },
+        "type": "object",
+        "required": [
+          "db_id"
+        ],
+        "title": "DatabaseConfig[LearningDomainConfig]"
       },
       "DatabaseConfig_MemoryDomainConfig_": {
         "properties": {
@@ -16204,6 +21692,39 @@
             ],
             "title": "Expected Tool Calls",
             "description": "Expected tool calls for reliability evaluation"
+          },
+          "allow_additional_tool_calls": {
+            "type": "boolean",
+            "title": "Allow Additional Tool Calls",
+            "description": "When True, tool calls not in expected_tool_calls are allowed (subset matching)",
+            "default": false
+          },
+          "expected_tool_call_arguments": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": true,
+                      "type": "object"
+                    },
+                    {
+                      "items": {
+                        "additionalProperties": true,
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Tool Call Arguments",
+            "description": "Expected arguments for specific tool calls, e.g. {\"tool_name\": {\"arg_name\": \"expected_value\"}} or {\"tool_name\": [{\"arg_name\": \"val1\"}, {\"arg_name\": \"val2\"}]}"
           }
         },
         "type": "object",
@@ -16304,6 +21825,18 @@
             "title": "Evaluated Component Name",
             "description": "Name of the evaluated component"
           },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id",
+            "description": "Owner of the evaluation run"
+          },
           "eval_type": {
             "$ref": "#/components/schemas/EvalType",
             "description": "Type of evaluation (accuracy, performance, or reliability)"
@@ -16385,20 +21918,6 @@
             ],
             "title": "Display Name"
           },
-          "available_models": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Available Models"
-          },
           "dbs": {
             "anyOf": [
               {
@@ -16430,25 +21949,122 @@
               }
             ],
             "title": "Display Name"
-          },
-          "available_models": {
-            "anyOf": [
-              {
-                "items": {
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Available Models"
           }
         },
         "type": "object",
         "title": "EvalsDomainConfig",
         "description": "Configuration for the Evals domain of the AgentOS"
+      },
+      "FilePart": {
+        "properties": {
+          "file": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FileWithBytes"
+              },
+              {
+                "$ref": "#/components/schemas/FileWithUri"
+              }
+            ],
+            "title": "File"
+          },
+          "kind": {
+            "type": "string",
+            "const": "file",
+            "title": "Kind",
+            "default": "file"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "FilePart",
+        "description": "Represents a file segment within a message or artifact. The file content can be\nprovided either directly as bytes or as a URI."
+      },
+      "FileWithBytes": {
+        "properties": {
+          "bytes": {
+            "type": "string",
+            "title": "Bytes"
+          },
+          "mimeType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mimetype"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "bytes"
+        ],
+        "title": "FileWithBytes",
+        "description": "Represents a file with its content provided directly as a base64-encoded string."
+      },
+      "FileWithUri": {
+        "properties": {
+          "mimeType": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mimetype"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "uri": {
+            "type": "string",
+            "title": "Uri"
+          }
+        },
+        "type": "object",
+        "required": [
+          "uri"
+        ],
+        "title": "FileWithUri",
+        "description": "Represents a file with its content located at a specific URI."
       },
       "FilterFieldSchema": {
         "properties": {
@@ -16569,6 +22185,78 @@
           "status": "ok"
         }
       },
+      "InfoResponse": {
+        "properties": {
+          "os_id": {
+            "type": "string",
+            "title": "Os Id",
+            "description": "Unique identifier for the OS instance"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Name of the OS instance"
+          },
+          "os_version": {
+            "type": "string",
+            "title": "Os Version",
+            "description": "Version of this AgentOS instance"
+          },
+          "agno_version": {
+            "type": "string",
+            "title": "Agno Version",
+            "description": "Version of the agno framework"
+          },
+          "agent_count": {
+            "type": "integer",
+            "title": "Agent Count",
+            "description": "Number of agents registered in the OS",
+            "default": 0
+          },
+          "team_count": {
+            "type": "integer",
+            "title": "Team Count",
+            "description": "Number of teams registered in the OS",
+            "default": 0
+          },
+          "workflow_count": {
+            "type": "integer",
+            "title": "Workflow Count",
+            "description": "Number of workflows registered in the OS",
+            "default": 0
+          },
+          "mcp": {
+            "$ref": "#/components/schemas/McpInfo",
+            "description": "MCP server availability for this OS instance"
+          },
+          "auth_mode": {
+            "type": "string",
+            "enum": [
+              "none",
+              "security_key",
+              "jwt"
+            ],
+            "title": "Auth Mode",
+            "description": "Authentication mode enforced on the REST/WS plane of this OS instance. MCP OAuth, when enabled, is described separately under `mcp.oauth`.",
+            "default": "none"
+          }
+        },
+        "type": "object",
+        "required": [
+          "os_id",
+          "os_version",
+          "agno_version"
+        ],
+        "title": "InfoResponse",
+        "description": "Response schema for the /info endpoint returning lightweight OS metadata."
+      },
       "InterfaceResponse": {
         "properties": {
           "type": {
@@ -16600,9 +22288,9 @@
           "detail": {
             "type": "string",
             "title": "Detail",
-            "description": "Error detail message"
+            "description": "Human-readable error message"
           },
-          "error_code": {
+          "error_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -16611,8 +22299,20 @@
                 "type": "null"
               }
             ],
-            "title": "Error Code",
-            "description": "Error code for categorization"
+            "title": "Error Id",
+            "description": "Stable identifier for the specific error, present only when the error carries one"
+          },
+          "error_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Type",
+            "description": "Category of the error, present only when the error carries one"
           }
         },
         "type": "object",
@@ -16621,8 +22321,7 @@
         ],
         "title": "InternalServerErrorResponse",
         "example": {
-          "detail": "Internal server error",
-          "error_code": "INTERNAL_SERVER_ERROR"
+          "detail": "Internal server error"
         }
       },
       "KeyResponse": {
@@ -16845,6 +22544,506 @@
         "title": "KnowledgeInstanceConfig",
         "description": "Configuration for a single knowledge instance"
       },
+      "LearningConfig": {
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "dbs": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/DatabaseConfig_LearningDomainConfig_"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dbs"
+          }
+        },
+        "type": "object",
+        "title": "LearningConfig",
+        "description": "Configuration for the Learning domain of the AgentOS"
+      },
+      "LearningCreate": {
+        "properties": {
+          "learning_type": {
+            "type": "string",
+            "title": "Learning Type",
+            "description": "Type of learning (e.g. 'user_profile', 'entity_memory')"
+          },
+          "content": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Content",
+            "description": "The learning content payload"
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Namespace",
+            "description": "Namespace for scoping ('user', 'global', or custom)"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id",
+            "description": "Associated user ID. When the request is authenticated, must match the JWT subject or be omitted/null (which creates a global / non-user-scoped record)."
+          },
+          "agent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id",
+            "description": "Associated agent ID"
+          },
+          "team_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Team Id",
+            "description": "Associated team ID"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id",
+            "description": "Associated session ID"
+          },
+          "entity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Id",
+            "description": "Associated entity ID"
+          },
+          "entity_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Type",
+            "description": "Entity type"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "Optional metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "learning_type",
+          "content"
+        ],
+        "title": "LearningCreate",
+        "description": "Request body for creating a learning record."
+      },
+      "LearningDomainConfig": {
+        "properties": {
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          }
+        },
+        "type": "object",
+        "title": "LearningDomainConfig",
+        "description": "Configuration for the Learning domain of the AgentOS"
+      },
+      "LearningResponse": {
+        "properties": {
+          "learning_id": {
+            "type": "string",
+            "title": "Learning Id",
+            "description": "Unique identifier for the learning record"
+          },
+          "learning_type": {
+            "type": "string",
+            "title": "Learning Type",
+            "description": "Type of learning (e.g. 'user_profile', 'entity_memory')"
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Namespace",
+            "description": "Namespace for scoping ('user', 'global', or custom)"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id",
+            "description": "Associated user ID"
+          },
+          "agent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id",
+            "description": "Associated agent ID"
+          },
+          "team_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Team Id",
+            "description": "Associated team ID"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id",
+            "description": "Associated session ID"
+          },
+          "entity_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Id",
+            "description": "Associated entity ID (for entity-specific learnings)"
+          },
+          "entity_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entity Type",
+            "description": "Entity type (e.g. 'person', 'company')"
+          },
+          "content": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content",
+            "description": "The learning content payload"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "Optional metadata"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At",
+            "description": "Creation timestamp (Unix epoch seconds)"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At",
+            "description": "Last update timestamp (Unix epoch seconds)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "learning_id",
+          "learning_type"
+        ],
+        "title": "LearningResponse",
+        "description": "A single learning record as returned by the API."
+      },
+      "LearningUpdate": {
+        "properties": {
+          "content": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content",
+            "description": "Replacement content payload"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "Replacement metadata"
+          }
+        },
+        "type": "object",
+        "title": "LearningUpdate",
+        "description": "Request body for updating a learning record. Identity fields are immutable."
+      },
+      "LearningUserStats": {
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "title": "User Id",
+            "description": "The user ID"
+          },
+          "last_learning_updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Learning Updated At",
+            "description": "Most recent learning update for this user (Unix epoch seconds)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "user_id"
+        ],
+        "title": "LearningUserStats",
+        "description": "A user that owns learning records, with their most recent activity.\n\nUsed as a lightweight index for the per-user view: list users here, then drill into a\nsingle user's records via ``GET /learnings?user_id=...``. No per-user count is returned\n-- the user-scoped stores (``user_profile``, ``user_memory``) keep a single record per\nuser, so a record count would always be 1; the actual memory count lives in that\nrecord's ``content``."
+      },
+      "Manifest": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "labels": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Labels"
+          },
+          "quick_prompts": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Quick Prompts"
+          }
+        },
+        "type": "object",
+        "title": "Manifest",
+        "description": "OS-level UI metadata for an agent/team/workflow.\n\nFields here are AgentOS UI metadata only. ``description`` is unrelated to\n``Agent.description`` / ``Team.description`` / ``Workflow.description``,\nwhich are sent to the model.\n\nRendering surfaces:\n- ``description``, ``labels``: home/landing card\n- ``quick_prompts``: chat page"
+      },
+      "McpInfo": {
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enabled",
+            "description": "Whether the MCP server is enabled on this OS instance",
+            "default": false
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Path",
+            "description": "Path where the MCP server is mounted, null when disabled"
+          },
+          "oauth": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/McpOAuthInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "OAuth discovery details when the MCP endpoint is OAuth-protected, null otherwise"
+          }
+        },
+        "type": "object",
+        "title": "McpInfo",
+        "description": "MCP server availability for the /info endpoint."
+      },
+      "McpOAuthInfo": {
+        "properties": {
+          "authorization_servers": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Authorization Servers",
+            "description": "Issuer URL(s) of the authorization server(s) protecting the MCP endpoint"
+          },
+          "resource": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resource",
+            "description": "RFC 9728 resource URL advertised for the MCP endpoint"
+          }
+        },
+        "type": "object",
+        "title": "McpOAuthInfo",
+        "description": "OAuth discovery details for an MCP endpoint protected by ``AgentOS(mcp_auth=...)``."
+      },
       "MeResponse": {
         "properties": {
           "id": {
@@ -16962,6 +23161,100 @@
         "title": "MemoryDomainConfig",
         "description": "Configuration for the Memory domain of the AgentOS"
       },
+      "Message": {
+        "properties": {
+          "contextId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contextid"
+          },
+          "extensions": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extensions"
+          },
+          "kind": {
+            "type": "string",
+            "const": "message",
+            "title": "Kind",
+            "default": "message"
+          },
+          "messageId": {
+            "type": "string",
+            "title": "Messageid"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "parts": {
+            "items": {
+              "$ref": "#/components/schemas/Part"
+            },
+            "type": "array",
+            "title": "Parts"
+          },
+          "referenceTaskIds": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Referencetaskids"
+          },
+          "role": {
+            "$ref": "#/components/schemas/Role"
+          },
+          "taskId": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Taskid"
+          }
+        },
+        "type": "object",
+        "required": [
+          "messageId",
+          "parts",
+          "role"
+        ],
+        "title": "Message",
+        "description": "Represents a single message in the conversation between a user and an agent."
+      },
       "Meta": {
         "properties": {
           "limit": {
@@ -17032,6 +23325,84 @@
         "type": "object",
         "title": "MetricsDomainConfig",
         "description": "Configuration for the Metrics domain of the AgentOS"
+      },
+      "MetricsRefreshResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Status of the refresh request"
+          },
+          "message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Message",
+            "description": "Additional details"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "MetricsRefreshResponse"
+      },
+      "MetricsRefreshStatusResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "Refresh status: 'idle', 'running', 'completed' or 'failed'"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At",
+            "description": "When the most recent refresh started"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At",
+            "description": "When the most recent refresh finished"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error",
+            "description": "Error message if the most recent refresh failed"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "title": "MetricsRefreshStatusResponse"
       },
       "MetricsResponse": {
         "properties": {
@@ -17140,9 +23511,9 @@
           "detail": {
             "type": "string",
             "title": "Detail",
-            "description": "Error detail message"
+            "description": "Human-readable error message"
           },
-          "error_code": {
+          "error_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -17151,8 +23522,20 @@
                 "type": "null"
               }
             ],
-            "title": "Error Code",
-            "description": "Error code for categorization"
+            "title": "Error Id",
+            "description": "Stable identifier for the specific error, present only when the error carries one"
+          },
+          "error_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Type",
+            "description": "Category of the error, present only when the error carries one"
           }
         },
         "type": "object",
@@ -17161,8 +23544,7 @@
         ],
         "title": "NotFoundResponse",
         "example": {
-          "detail": "Not found",
-          "error_code": "NOT_FOUND"
+          "detail": "Not found"
         }
       },
       "OptimizeMemoriesRequest": {
@@ -17347,6 +23729,50 @@
         ],
         "title": "PaginatedResponse[EvalSchema]"
       },
+      "PaginatedResponse_LearningResponse_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/LearningResponse"
+            },
+            "type": "array",
+            "title": "Data",
+            "description": "List of items for the current page"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationInfo",
+            "description": "Pagination metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "PaginatedResponse[LearningResponse]"
+      },
+      "PaginatedResponse_LearningUserStats_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/LearningUserStats"
+            },
+            "type": "array",
+            "title": "Data",
+            "description": "List of items for the current page"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationInfo",
+            "description": "Pagination metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "PaginatedResponse[LearningUserStats]"
+      },
       "PaginatedResponse_RegistryContentResponse_": {
         "properties": {
           "data": {
@@ -17412,6 +23838,28 @@
           "meta"
         ],
         "title": "PaginatedResponse[ScheduleRunResponse]"
+      },
+      "PaginatedResponse_ServiceAccountResponse_": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ServiceAccountResponse"
+            },
+            "type": "array",
+            "title": "Data",
+            "description": "List of items for the current page"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationInfo",
+            "description": "Pagination metadata"
+          }
+        },
+        "type": "object",
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "PaginatedResponse[ServiceAccountResponse]"
       },
       "PaginatedResponse_SessionSchema_": {
         "properties": {
@@ -17573,7 +24021,7 @@
             "type": "integer",
             "minimum": 0.0,
             "title": "Page",
-            "description": "Current page number (0-indexed)",
+            "description": "Current page number (1-indexed)",
             "default": 0
           },
           "limit": {
@@ -17607,6 +24055,20 @@
         },
         "type": "object",
         "title": "PaginationInfo"
+      },
+      "Part": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/TextPart"
+          },
+          {
+            "$ref": "#/components/schemas/FilePart"
+          },
+          {
+            "$ref": "#/components/schemas/DataPart"
+          }
+        ],
+        "title": "Part"
       },
       "ReaderSchema": {
         "properties": {
@@ -17653,6 +24115,39 @@
             ],
             "title": "Chunkers",
             "description": "List of supported chunking strategies"
+          },
+          "content_types": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Types",
+            "description": "Content types this reader can read in this install"
+          },
+          "unavailable_content_types": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Unavailable Content Types",
+            "description": "Content types this reader supports but cannot read here, and the packages each needs"
           }
         },
         "type": "object",
@@ -17722,7 +24217,12 @@
           "schema",
           "function",
           "agent",
-          "team"
+          "team",
+          "workflow",
+          "knowledge",
+          "memory_manager",
+          "session_summary_manager",
+          "learning"
         ],
         "title": "RegistryResourceType",
         "description": "Types of resources that can be stored in a registry."
@@ -17778,6 +24278,15 @@
         ],
         "title": "RemoteContentSourceSchema",
         "description": "Schema for remote content source configuration."
+      },
+      "Role": {
+        "type": "string",
+        "enum": [
+          "agent",
+          "user"
+        ],
+        "title": "Role",
+        "description": "Identifies the sender of the message. `user` for the client, `agent` for the service."
       },
       "RunSchema": {
         "properties": {
@@ -18138,6 +24647,66 @@
             ],
             "title": "Followups",
             "description": "Followup suggestions generated after the run"
+          },
+          "forked_from_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forked From Run Id",
+            "description": "If this run was forked from another run, the source run's ID"
+          },
+          "forked_from_message_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forked From Message Index",
+            "description": "If this run was forked, the message index at which the source was truncated"
+          },
+          "forked_from_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forked From Session Id",
+            "description": "If this run was created via session branch, the source session's ID"
+          },
+          "regenerated_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Regenerated From",
+            "description": "If this run was produced via regenerate=true, the source run's ID"
+          },
+          "last_checkpoint_at_message_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Checkpoint At Message Index",
+            "description": "Message index of the most recent mid-run checkpoint (checkpoint='tool-batch' runs)"
           }
         },
         "type": "object",
@@ -18154,7 +24723,8 @@
           "COMPLETED",
           "PAUSED",
           "CANCELLED",
-          "ERROR"
+          "ERROR",
+          "REGENERATED"
         ],
         "title": "RunStatus",
         "description": "State of the main run response"
@@ -18248,6 +24818,17 @@
             "type": "string",
             "title": "Id"
           },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          },
           "name": {
             "type": "string",
             "title": "Name"
@@ -18318,6 +24899,50 @@
             ],
             "title": "Next Run At"
           },
+          "managed_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Managed By"
+          },
+          "target_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Type"
+          },
+          "target_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Id"
+          },
+          "disabled_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Disabled Reason"
+          },
           "created_at": {
             "anyOf": [
               {
@@ -18365,6 +24990,17 @@
           "schedule_id": {
             "type": "string",
             "title": "Schedule Id"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
           },
           "attempt": {
             "type": "integer",
@@ -18675,6 +25311,392 @@
         "type": "object",
         "title": "ScheduleUpdate"
       },
+      "ScopeItem": {
+        "properties": {
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "description": "Scope string, e.g. 'agents:*:run'"
+          },
+          "effect": {
+            "type": "string",
+            "enum": [
+              "allow",
+              "deny"
+            ],
+            "title": "Effect",
+            "description": "'allow' or 'deny'",
+            "default": "allow"
+          }
+        },
+        "type": "object",
+        "required": [
+          "scope"
+        ],
+        "title": "ScopeItem",
+        "description": "Write shape for one scope grant \u2014 the canonical RBAC payload for every scope-bearing API.\n\nEndpoints that take scopes accept these objects only (a bare string is a validation\nerror). ``effect`` is constrained here so every consumer rejects typos at the model\nlayer; whether ``deny`` is *semantically* legal stays per-endpoint (roles support\ndeny rules, service-account tokens are pure grants and reject it)."
+      },
+      "ScopeSchema": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id",
+            "description": "Scope id (always null here; kept for shape parity with the cloud RBAC API, which addresses scopes individually)"
+          },
+          "raw": {
+            "type": "string",
+            "title": "Raw",
+            "description": "Original scope string, e.g. 'agents:*:run'"
+          },
+          "namespace": {
+            "type": "string",
+            "title": "Namespace",
+            "description": "Resource namespace, e.g. 'agents'"
+          },
+          "sub_namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sub Namespace",
+            "description": "Specific resource id or wildcard '*'"
+          },
+          "permission": {
+            "type": "string",
+            "title": "Permission",
+            "description": "Action, e.g. 'read' / 'run' / 'write'"
+          },
+          "value": {
+            "type": "string",
+            "title": "Value",
+            "description": "'allow' or 'deny'",
+            "default": "allow"
+          }
+        },
+        "type": "object",
+        "required": [
+          "raw",
+          "namespace",
+          "permission"
+        ],
+        "title": "ScopeSchema",
+        "description": "Read shape for one scope \u2014 the parsed RBAC payload shared by every scope-bearing API.\n\nMirrors the cloud RBAC scope shape ({raw, namespace, sub_namespace, permission, value})\nso a frontend renders scopes from any AgentOS API with one integration."
+      },
+      "SendMessageSuccessResponse": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "jsonrpc": {
+            "type": "string",
+            "const": "2.0",
+            "title": "Jsonrpc",
+            "default": "2.0"
+          },
+          "result": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Task"
+              },
+              {
+                "$ref": "#/components/schemas/Message"
+              }
+            ],
+            "title": "Result"
+          }
+        },
+        "type": "object",
+        "required": [
+          "result"
+        ],
+        "title": "SendMessageSuccessResponse",
+        "description": "Represents a successful JSON-RPC response for the `message/send` method."
+      },
+      "ServiceAccountCreate": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 63,
+            "title": "Name",
+            "description": "Machine identity name (lowercase slug), e.g. 'claude-code' or 'github-actions'"
+          },
+          "scopes": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ScopeItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scopes",
+            "description": "Scopes granted to the token, as {scope, effect} objects (the shared RBAC write shape; token scopes are grants, so only effect='allow' is accepted). Defaults to run and read scopes: agents:run, teams:run, workflows:run, sessions:read"
+          },
+          "expires_in_days": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "maximum": 3650.0,
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires In Days",
+            "description": "Days until the token expires (default: 90)",
+            "default": 90
+          },
+          "never_expires": {
+            "type": "boolean",
+            "title": "Never Expires",
+            "description": "Mint a non-expiring token. Must be set explicitly; overrides expires_in_days.",
+            "default": false
+          },
+          "allow_privileged_scopes": {
+            "type": "boolean",
+            "title": "Allow Privileged Scopes",
+            "description": "Required to grant privileged scopes: any write or delete action, the admin scope, or any service_accounts scope. Privileged tokens must be deliberate, never accidental.",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "ServiceAccountCreate"
+      },
+      "ServiceAccountCreateResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "principal": {
+            "type": "string",
+            "title": "Principal",
+            "description": "The user_id attached to runs made with this token, e.g. 'sa:claude-code'"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id",
+            "description": "The user this account belongs to; None for workspace-level accounts. Distinct from created_by, which records who minted the token."
+          },
+          "token_prefix": {
+            "type": "string",
+            "title": "Token Prefix",
+            "description": "First characters of the token, for display only"
+          },
+          "scopes": {
+            "items": {
+              "$ref": "#/components/schemas/ScopeSchema"
+            },
+            "type": "array",
+            "title": "Scopes",
+            "description": "Scopes granted to the token, in the shared RBAC read shape"
+          },
+          "created_at": {
+            "type": "integer",
+            "title": "Created At"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          },
+          "token": {
+            "type": "string",
+            "title": "Token",
+            "description": "The plaintext token. Shown exactly once - store it securely now."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "principal",
+          "token_prefix",
+          "created_at",
+          "token"
+        ],
+        "title": "ServiceAccountCreateResponse",
+        "description": "Returned once, at creation. The token is never retrievable again."
+      },
+      "ServiceAccountResponse": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "principal": {
+            "type": "string",
+            "title": "Principal",
+            "description": "The user_id attached to runs made with this token, e.g. 'sa:claude-code'"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id",
+            "description": "The user this account belongs to; None for workspace-level accounts. Distinct from created_by, which records who minted the token."
+          },
+          "token_prefix": {
+            "type": "string",
+            "title": "Token Prefix",
+            "description": "First characters of the token, for display only"
+          },
+          "scopes": {
+            "items": {
+              "$ref": "#/components/schemas/ScopeSchema"
+            },
+            "type": "array",
+            "title": "Scopes",
+            "description": "Scopes granted to the token, in the shared RBAC read shape"
+          },
+          "created_at": {
+            "type": "integer",
+            "title": "Created At"
+          },
+          "expires_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At"
+          },
+          "last_used_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Used At"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
+          },
+          "created_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created By"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "principal",
+          "token_prefix",
+          "created_at"
+        ],
+        "title": "ServiceAccountResponse",
+        "description": "Service account metadata. Never includes the token hash or plaintext."
+      },
       "SessionConfig": {
         "properties": {
           "display_name": {
@@ -18775,6 +25797,117 @@
             ],
             "title": "Updated At",
             "description": "Timestamp when session was last updated"
+          },
+          "session_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Type",
+            "description": "Type of session: agent, team, or workflow"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id",
+            "description": "User ID associated with the session"
+          },
+          "agent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id",
+            "description": "Agent ID if this is an agent session"
+          },
+          "team_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Team Id",
+            "description": "Team ID if this is a team session"
+          },
+          "workflow_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workflow Id",
+            "description": "Workflow ID if this is a workflow session"
+          },
+          "session_summary": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Summary",
+            "description": "Summary of session interactions"
+          },
+          "metrics": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metrics",
+            "description": "Session metrics"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Tokens",
+            "description": "Total tokens used in this session"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata",
+            "description": "Additional metadata"
           }
         },
         "type": "object",
@@ -18792,6 +25925,91 @@
           "workflow"
         ],
         "title": "SessionType"
+      },
+      "SetAgentModelRequest": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "model"
+        ],
+        "title": "SetAgentModelRequest"
+      },
+      "SetCurrentRequest": {
+        "properties": {
+          "guard": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ComponentGuard"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional compare-and-set guard"
+          }
+        },
+        "type": "object",
+        "title": "SetCurrentRequest",
+        "description": "Body for set-current. Optional: an empty POST keeps working."
+      },
+      "SetModelResponse": {
+        "properties": {
+          "component_id": {
+            "type": "string",
+            "title": "Component Id"
+          },
+          "member_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Member Id"
+          },
+          "model": {
+            "$ref": "#/components/schemas/Model"
+          }
+        },
+        "type": "object",
+        "required": [
+          "component_id",
+          "model"
+        ],
+        "title": "SetModelResponse"
+      },
+      "SetTeamModelRequest": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "member_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Member Id"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "model"
+        ],
+        "title": "SetTeamModelRequest"
       },
       "SortOrder": {
         "type": "string",
@@ -18939,6 +26157,128 @@
         ],
         "title": "SourceFolderSchema",
         "description": "Schema for a folder in a content source."
+      },
+      "Task": {
+        "properties": {
+          "artifacts": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Artifact"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Artifacts"
+          },
+          "contextId": {
+            "type": "string",
+            "title": "Contextid"
+          },
+          "history": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Message"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "History"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "kind": {
+            "type": "string",
+            "const": "task",
+            "title": "Kind",
+            "default": "task"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TaskStatus"
+          }
+        },
+        "type": "object",
+        "required": [
+          "contextId",
+          "id",
+          "status"
+        ],
+        "title": "Task",
+        "description": "Represents a single, stateful operation or conversation between a client and an agent."
+      },
+      "TaskState": {
+        "type": "string",
+        "enum": [
+          "submitted",
+          "working",
+          "input-required",
+          "completed",
+          "canceled",
+          "failed",
+          "rejected",
+          "auth-required",
+          "unknown"
+        ],
+        "title": "TaskState",
+        "description": "Defines the lifecycle states of a Task."
+      },
+      "TaskStatus": {
+        "properties": {
+          "message": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Message"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "state": {
+            "$ref": "#/components/schemas/TaskState"
+          },
+          "timestamp": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timestamp",
+            "examples": [
+              "2023-10-27T10:00:00Z"
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "title": "TaskStatus",
+        "description": "Represents the status of a task at a specific point in time."
       },
       "TeamResponse": {
         "properties": {
@@ -19181,6 +26521,23 @@
               }
             ],
             "title": "Input Schema"
+          },
+          "is_factory": {
+            "type": "boolean",
+            "title": "Is Factory",
+            "default": false
+          },
+          "factory_input_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Input Schema"
           },
           "is_component": {
             "type": "boolean",
@@ -19560,6 +26917,66 @@
             ],
             "title": "Followups",
             "description": "Followup suggestions generated after the run"
+          },
+          "forked_from_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forked From Run Id",
+            "description": "If this team run was forked from another run, the source run's ID"
+          },
+          "forked_from_message_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forked From Message Index",
+            "description": "If this team run was forked, the message index at which the source was truncated"
+          },
+          "forked_from_session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forked From Session Id",
+            "description": "If this team run was created via session branch, the source session's ID"
+          },
+          "regenerated_from": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Regenerated From",
+            "description": "If this team run was produced via regenerate=true, the source run's ID"
+          },
+          "last_checkpoint_at_message_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Checkpoint At Message Index",
+            "description": "Message index of the most recent mid-run checkpoint (checkpoint='tool-batch' runs)"
           }
         },
         "type": "object",
@@ -19792,6 +27209,17 @@
             ],
             "title": "Mode",
             "description": "Team execution mode (coordinate, route, broadcast, tasks)"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Model"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Model used by the team leader"
           }
         },
         "type": "object",
@@ -19814,6 +27242,38 @@
           "message"
         ],
         "title": "TestConnectionResponse"
+      },
+      "TextPart": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "const": "text",
+            "title": "Kind",
+            "default": "text"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "text": {
+            "type": "string",
+            "title": "Text"
+          }
+        },
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "title": "TextPart",
+        "description": "Represents a text segment within a message or artifact."
       },
       "TraceDetail": {
         "properties": {
@@ -20477,9 +27937,9 @@
           "detail": {
             "type": "string",
             "title": "Detail",
-            "description": "Error detail message"
+            "description": "Human-readable error message"
           },
-          "error_code": {
+          "error_id": {
             "anyOf": [
               {
                 "type": "string"
@@ -20488,8 +27948,20 @@
                 "type": "null"
               }
             ],
-            "title": "Error Code",
-            "description": "Error code for categorization"
+            "title": "Error Id",
+            "description": "Stable identifier for the specific error, present only when the error carries one"
+          },
+          "error_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Type",
+            "description": "Category of the error, present only when the error carries one"
           }
         },
         "type": "object",
@@ -20498,9 +27970,112 @@
         ],
         "title": "UnauthenticatedResponse",
         "example": {
-          "detail": "Unauthenticated access",
-          "error_code": "UNAUTHENTICATED"
+          "detail": "Unauthenticated access"
         }
+      },
+      "UnavailableChunkerSchema": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Chunker key that could not be loaded"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Name of the chunker"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "Description of the chunking strategy"
+          },
+          "missing_packages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Packages",
+            "description": "Packages that are not importable"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason",
+            "description": "Verbatim import failure, including its install instruction"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "reason"
+        ],
+        "title": "UnavailableChunkerSchema"
+      },
+      "UnavailableReaderSchema": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Reader key that could not be loaded"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Name of the reader"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "Description of the reader's capabilities"
+          },
+          "missing_packages": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Missing Packages",
+            "description": "Packages that are not importable"
+          },
+          "reason": {
+            "type": "string",
+            "title": "Reason",
+            "description": "Verbatim import failure, including its install instruction"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "reason"
+        ],
+        "title": "UnavailableReaderSchema"
       },
       "UpdateConnectionRequest": {
         "properties": {
@@ -20568,6 +28143,18 @@
               }
             ],
             "title": "Password"
+          },
+          "memory_namespace": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Memory Namespace"
           }
         },
         "type": "object",
@@ -20849,24 +28436,59 @@
         ],
         "title": "ValidationError"
       },
+      "ValidationErrorDetail": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Loc",
+            "description": "Path to the offending field, e.g. ['body', 'endpoint']"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "description": "Human-readable error message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "description": "Error type identifier, e.g. 'value_error' or 'missing'"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationErrorDetail",
+        "description": "One field-level error inside a 422 body, matching FastAPI's default shape."
+      },
       "ValidationErrorResponse": {
         "properties": {
           "detail": {
-            "type": "string",
-            "title": "Detail",
-            "description": "Error detail message"
-          },
-          "error_code": {
             "anyOf": [
               {
                 "type": "string"
               },
               {
-                "type": "null"
+                "items": {
+                  "$ref": "#/components/schemas/ValidationErrorDetail"
+                },
+                "type": "array"
               }
             ],
-            "title": "Error Code",
-            "description": "Error code for categorization"
+            "title": "Detail",
+            "description": "A single message for an explicitly raised 422, or a list of field-level errors for a request-validation failure"
           }
         },
         "type": "object",
@@ -20874,9 +28496,18 @@
           "detail"
         ],
         "title": "ValidationErrorResponse",
+        "description": "422 body. Two runtime shapes share this status code, and the same endpoint can\nreturn either, so ``detail`` is typed as their union:\n\n- FastAPI's request-validation handler emits a **list** of field-level errors (built-in\n  coercion errors and custom-validator ``ValueError``s alike).\n- A route that raises ``HTTPException(status_code=422, detail=\"...\")`` for a semantic\n  check (e.g. an invalid cron expression) emits a **string** through the HTTPException\n  handler.",
         "example": {
-          "detail": "Validation error",
-          "error_code": "VALIDATION_ERROR"
+          "detail": [
+            {
+              "loc": [
+                "body",
+                "endpoint"
+              ],
+              "msg": "Value error, Endpoint must be a path, not a full URL",
+              "type": "value_error"
+            }
+          ]
         }
       },
       "VectorDbSchema": {
@@ -21039,7 +28670,14 @@
       "VectorSearchResult": {
         "properties": {
           "id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id",
             "description": "Unique identifier for the search result document"
           },
@@ -21140,7 +28778,6 @@
         },
         "type": "object",
         "required": [
-          "id",
           "content"
         ],
         "title": "VectorSearchResult",
@@ -21265,6 +28902,25 @@
             "title": "Workflow Agent",
             "description": "Whether this workflow uses a WorkflowAgent",
             "default": false
+          },
+          "is_factory": {
+            "type": "boolean",
+            "title": "Is Factory",
+            "description": "Whether this workflow is a factory",
+            "default": false
+          },
+          "factory_input_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Input Schema",
+            "description": "JSON Schema for factory_input"
           },
           "is_component": {
             "type": "boolean",
@@ -21430,6 +29086,58 @@
             ],
             "title": "Step Executor Runs",
             "description": "Executor runs for each step"
+          },
+          "step_requirements": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Step Requirements",
+            "description": "HITL step requirements (resolved state for historical display)"
+          },
+          "pause_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pause Kind",
+            "description": "Kind of HITL pause: 'step' or 'executor'"
+          },
+          "paused_step_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Step Name",
+            "description": "Name of the step that caused the pause"
+          },
+          "paused_step_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paused Step Index",
+            "description": "Index of the step that caused the pause"
           },
           "metrics": {
             "anyOf": [
@@ -21797,6 +29505,25 @@
             ],
             "title": "Db Id",
             "description": "Database identifier"
+          },
+          "is_factory": {
+            "type": "boolean",
+            "title": "Is Factory",
+            "description": "Whether this workflow is a factory",
+            "default": false
+          },
+          "factory_input_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Factory Input Schema",
+            "description": "JSON Schema for factory_input"
           },
           "is_component": {
             "type": "boolean",

--- a/src/generated/types.ts
+++ b/src/generated/types.ts
@@ -209,6 +209,86 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/agents:apply": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Apply Agent
+         * @description Create, apply (upsert), or update an IBM i agent from a friendly manifest.
+         */
+        post: operations["apply_agent_agents_apply_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agents/{component_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Agent
+         * @description Delete a DB-backed agent component.
+         */
+        delete: operations["delete_agent_agents__component_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/toolsets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Toolsets Route
+         * @description List the curated IBM i toolset catalog (name, title, description, tool_count).
+         */
+        get: operations["list_toolsets_route_toolsets_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/toolsets/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Toolset Route
+         * @description Return one toolset's raw entry (tools, source, title, description, tool_metadata).
+         */
+        get: operations["get_toolset_route_toolsets__name__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -221,6 +301,26 @@ export interface paths {
          * @description Check the health status of the AgentOS API. Returns a simple status indicator.
          */
         get: operations["health_check"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/info": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get OS Info
+         * @description Return lightweight, unauthenticated metadata about this AgentOS instance.
+         */
+        get: operations["get_info"];
         put?: never;
         post?: never;
         delete?: never;
@@ -246,26 +346,6 @@ export interface paths {
          *     - Available interfaces and their routes
          */
         get: operations["get_config"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/models": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Available Models
-         * @description Retrieve a list of all unique models currently used by agents and teams in this OS instance. This includes the model ID and provider information for each model.
-         */
-        get: operations["get_models"];
         put?: never;
         post?: never;
         delete?: never;
@@ -343,18 +423,40 @@ export interface paths {
         put?: never;
         /**
          * Continue Agent Run
-         * @description Continue a paused or incomplete agent run with updated tool results.
+         * @description Advance a persisted agent run from its current state. Dispatches on the body shape and the persisted run state.
          *
-         *     **Use Cases:**
-         *     - Resume execution after tool approval/rejection
-         *     - Provide manual tool execution results
-         *     - Resume after admin approval (tools can be empty; resolution fetched from DB)
+         *     **Variants:**
+         *     - PAUSED + tools provided → apply HITL tool results, resume
+         *     - PAUSED + resolved admin approval (empty tools) → apply resolution, resume
+         *     - RUNNING / ERROR (no unresolved HITL requirements) → resume from last persisted state
+         *     - COMPLETED + new tools → continue with appended messages
          *
          *     **Tools Parameter:**
-         *     JSON string containing array of tool execution objects with results.
-         *     Can be empty when an admin-required approval has been resolved.
+         *     JSON string containing array of tool execution objects with results. Optional — only required when the persisted run has unresolved HITL requirements.
          */
         post: operations["continue_agent_run"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agents/{agent_id}/sessions/{session_id}/fork": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Fork Agent Session
+         * @description Deep-copy a session into a new independent session. Every run is copied with a fresh ``run_id``; the new session has a fresh ``session_id``. The original is untouched. Use to explore alternative conversation paths without mutating the source.
+         *
+         *     Distinct from ``/continue?fork=true``: that creates a sibling **run** inside the **same** session. This creates a sibling **session**.
+         */
+        post: operations["fork_agent_session"];
         delete?: never;
         options?: never;
         head?: never;
@@ -438,6 +540,76 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/agents/{agent_id}/runs/{run_id}/checkpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Agent Run Checkpoints
+         * @description List FE-friendly continuation boundaries derived from the current stored run. No separate checkpoint table is used; entries are inferred from message-level checkpoint markers and the terminal end of the transcript.
+         */
+        get: operations["list_agent_run_checkpoints"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agents/{agent_id}/runs/{run_id}/checkpoints/{message_index}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Agent Run Checkpoint Snapshot
+         * @description Return a derived run snapshot truncated at a message boundary. Use the returned message_index as `continue_from` when continuing this run.
+         */
+        get: operations["get_agent_run_checkpoint_snapshot"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agents/{agent_id}/runs/{run_id}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume Agent Run Stream
+         * @description Resume an SSE stream for an agent run after disconnection.
+         *
+         *     Sends missed events since `last_event_index`, then continues streaming live events if the run is still active.
+         *
+         *     **Three reconnection paths:**
+         *     1. **Run still active**: Sends catch-up events + continues live streaming
+         *     2. **Run completed (in buffer)**: Replays missed buffered events
+         *     3. **Run completed (in database)**: Replays events from database
+         *
+         *     **Client usage:**
+         *     Track `event_index` from each SSE event. On reconnection, pass the last received `event_index` as `last_event_index`.
+         */
+        post: operations["resume_agent_run_stream"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/teams/{team_id}/runs": {
         parameters: {
             query?: never;
@@ -490,6 +662,87 @@ export interface paths {
          *     **Note:** Cancellation may not be immediate for all operations.
          */
         post: operations["cancel_team_run"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams/{team_id}/runs/{run_id}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume Team Run Stream
+         * @description Resume an SSE stream for a team run after disconnection.
+         *
+         *     Sends missed events since `last_event_index`, then continues streaming live events if the run is still active.
+         *
+         *     **Three reconnection paths:**
+         *     1. **Run still active**: Sends catch-up events + continues live streaming
+         *     2. **Run completed (in buffer)**: Replays missed buffered events
+         *     3. **Run completed (in database)**: Replays events from database
+         *
+         *     **Client usage:**
+         *     Track `event_index` from each SSE event. On reconnection, pass the last received `event_index` as `last_event_index`.
+         */
+        post: operations["resume_team_run_stream"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams/{team_id}/runs/{run_id}/continue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Continue Team Run
+         * @description Continue a paused or incomplete team run with updated requirements.
+         *
+         *     **Use Cases:**
+         *     - Resume execution after tool approval/rejection
+         *     - Provide manual tool execution results
+         *     - Resume after admin approval (requirements can be empty; resolution fetched from DB)
+         *
+         *     **Requirements Parameter:**
+         *     JSON string containing array of requirement objects with tool execution results.
+         *     Can be empty when an admin-required approval has been resolved.
+         */
+        post: operations["continue_team_run"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams/{team_id}/sessions/{session_id}/fork": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Fork Team Session
+         * @description Deep-copy a team session into a new independent session. Every run is copied with a fresh ``run_id``; the new session has a fresh ``session_id``. The original is untouched. Use to explore alternative conversation paths without mutating the source.
+         *
+         *     Distinct from ``/continue?fork=true``: that creates a sibling **run** inside the **same** session. This creates a sibling **session**.
+         */
+        post: operations["fork_team_session"];
         delete?: never;
         options?: never;
         head?: never;
@@ -564,6 +817,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/teams/{team_id}/runs/{run_id}/checkpoints": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Team Run Checkpoints
+         * @description List FE-friendly continuation boundaries derived from the current stored team run. No separate checkpoint table is used; entries are inferred from message-level checkpoint markers and the terminal end of the transcript.
+         */
+        get: operations["list_team_run_checkpoints"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/teams/{team_id}/runs/{run_id}/checkpoints/{message_index}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Team Run Checkpoint Snapshot
+         * @description Return a derived team run snapshot truncated at a message boundary. Use the returned message_index as `continue_from` when continuing this run.
+         */
+        get: operations["get_team_run_checkpoint_snapshot"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/workflows": {
         parameters: {
             query?: never;
@@ -617,7 +910,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * List Workflow Runs
+         * @description List runs for a workflow within a session, optionally filtered by status.
+         *
+         *     Useful for monitoring background runs and viewing run history.
+         */
+        get: operations["list_workflow_runs"];
         put?: never;
         /**
          * Execute Workflow
@@ -638,6 +937,33 @@ export interface paths {
          *     Workflows support session continuity for stateful execution across multiple runs.
          */
         post: operations["create_workflow_run"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/workflows/{workflow_id}/runs/{run_id}/continue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Continue Workflow Run
+         * @description Continue a paused workflow run with resolved requirements.
+         *
+         *     **Use Cases:**
+         *     - Resume after step-level HITL (confirmation, user input, router selection)
+         *     - Resume after executor-level HITL (agent/team tool confirmation within a step)
+         *
+         *     **Requirements Parameter:**
+         *     JSON string containing the resolved step requirements.
+         */
+        post: operations["continue_workflow_run"];
         delete?: never;
         options?: never;
         head?: never;
@@ -665,6 +991,36 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/workflows/{workflow_id}/runs/{run_id}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resume Workflow Run Stream
+         * @description Resume an SSE stream for a workflow run after disconnection.
+         *
+         *     Sends missed events since `last_event_index`, then continues streaming live events if the run is still active.
+         *
+         *     **Three reconnection paths:**
+         *     1. **Run still active**: Sends catch-up events + continues live streaming
+         *     2. **Run completed (in buffer)**: Replays missed buffered events
+         *     3. **Run completed (in database)**: Replays events from database
+         *
+         *     **Client usage:**
+         *     Track `event_index` from each SSE event. On reconnection, pass the last received `event_index` as `last_event_index`.
+         */
+        post: operations["resume_workflow_run_stream"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/workflows/{workflow_id}/runs/{run_id}": {
         parameters: {
             query?: never;
@@ -681,6 +1037,278 @@ export interface paths {
         get: operations["get_workflow_run"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Disabled */
+        get: operations["disabled_queue_get"];
+        /** Disabled */
+        put: operations["disabled_queue_put"];
+        /** Disabled */
+        post: operations["disabled_queue_post"];
+        /** Disabled */
+        delete: operations["disabled_queue_delete"];
+        options?: never;
+        head?: never;
+        /** Disabled */
+        patch: operations["disabled_queue_patch"];
+        trace?: never;
+    };
+    "/a2a/agents/{id}/.well-known/agent-card.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Agent Card */
+        get: operations["get_agent_card_a2a_agents__id___well_known_agent_card_json_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/agents/{id}/v1/message:send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run Message Agent
+         * @description Send a message to an Agno Agent (non-streaming). The Agent is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata.
+         */
+        post: operations["run_message_agent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/agents/{id}/v1/tasks:get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Get Agent Task
+         * @description Get the status and result of an agent task by ID.
+         */
+        post: operations["get_agent_task"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/agents/{id}/v1/tasks:cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cancel Agent Task
+         * @description Cancel a running agent task.
+         */
+        post: operations["cancel_agent_task"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/agents/{id}/v1/message:stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stream Message Agent
+         * @description Stream a message to an Agno Agent (streaming). The Agent is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata. Returns real-time updates as newline-delimited JSON (NDJSON).
+         */
+        post: operations["stream_message_agent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/teams/{id}/.well-known/agent-card.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Team Card */
+        get: operations["get_team_card_a2a_teams__id___well_known_agent_card_json_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/teams/{id}/v1/message:send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run Message Team
+         * @description Send a message to an Agno Team (non-streaming). The Team is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata.
+         */
+        post: operations["run_message_team"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/teams/{id}/v1/tasks:get": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Get Team Task
+         * @description Get the status and result of a team task by ID.
+         */
+        post: operations["get_team_task"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/teams/{id}/v1/tasks:cancel": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Cancel Team Task
+         * @description Cancel a running team task.
+         */
+        post: operations["cancel_team_task"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/teams/{id}/v1/message:stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stream Message Team
+         * @description Stream a message to an Agno Team (streaming). The Team is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata. Returns real-time updates as newline-delimited JSON (NDJSON).
+         */
+        post: operations["stream_message_team"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/workflows/{id}/.well-known/agent-card.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Workflow Card */
+        get: operations["get_workflow_card_a2a_workflows__id___well_known_agent_card_json_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/workflows/{id}/v1/message:send": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run Message Workflow
+         * @description Send a message to an Agno Workflow (non-streaming). The Workflow is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata.
+         */
+        post: operations["run_message_workflow"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/a2a/workflows/{id}/v1/message:stream": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Stream Message Workflow
+         * @description Stream a message to an Agno Workflow (streaming). The Workflow is identified via the path parameter '{id}'. Optional: Pass user ID via X-User-ID header (recommended) or 'userId' in params.message.metadata. Returns real-time updates as newline-delimited JSON (NDJSON).
+         */
+        post: operations["stream_message_workflow"];
         delete?: never;
         options?: never;
         head?: never;
@@ -803,6 +1431,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/sessions/{session_id}/media/{storage_key}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Fetch stored media for a session
+         * @description Stream (or, with redirect=true, redirect to a freshly-signed URL for) a piece of media stored in external media storage. Scoped to the caller's session ownership; the storage_key must belong to the session.
+         */
+        get: operations["get_session_media"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/memories": {
         parameters: {
             query?: never;
@@ -919,6 +1567,98 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/learnings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Learnings
+         * @description List learning records with pagination and optional filters. For a scoped (non-admin) caller with user isolation enabled, results are bound to that user and also include records with no owner (`user_id IS NULL`) — this covers global, agent, team, session, and entity-scoped learnings; passing a `user_id` that differs from the caller is rejected with 403. Admins and unscoped callers see all records (optionally filtered by `user_id`).
+         */
+        get: operations["list_learnings"];
+        put?: never;
+        /**
+         * Create Learning
+         * @description Create a new learning record. For the identity-keyed learning types (`user_profile`, `user_memory`, `session_context`, `entity_memory`) the record id is derived deterministically from the identity fields so it reconciles with what the agent reads/writes — provide those fields (else 422), and if a record already exists the request is rejected with 409 (use PATCH to update it). Other types get a generated id. For a scoped (non-admin) caller, the body's `user_id` must be omitted/null or match the caller (mismatch → 403); admins and unscoped callers may set any `user_id`. An `entity_memory` record whose body omits `namespace` is stored under the `global` default; the endpoint cannot see how a given store is configured, so a caller writing for a store running with `namespace="user"` or a custom namespace must pass `namespace` explicitly or the record will not be visible to it.
+         */
+        post: operations["create_learning"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learnings/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Learning Users
+         * @description List the users that own learning records, with a per-user count and last-updated timestamp. Intended as the entry point for a per-user view: list users here, then drill into a single user's learnings via `GET /learnings?user_id=...`. Records with no owner (`user_id IS NULL`) are excluded. Pass `learning_type` to restrict the grouping to a single store (e.g. `user_profile` or `user_memory`). For a scoped (non-admin) caller results are bound to that user; an explicit `user_id` that differs is rejected with 403. Admins and unscoped callers list all users. Sortable by `user_id` or `last_learning_updated_at` (the default).
+         */
+        get: operations["list_learning_users"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learnings/users/{user_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Learning User
+         * @description Delete the learning records owned by a user. By default removes every learning type backed by the agno_learnings table (user_profile, user_memory, and any user-scoped entity records); pass `learning_type` to restrict deletion to a single store. Records with no owner (`user_id IS NULL`) are not affected. For a scoped (non-admin) caller, only their own learnings may be deleted; a different `user_id` is rejected with 403. Admins and unscoped callers may delete any user's learnings. Returns 204 even if the user had no matching records.
+         */
+        delete: operations["delete_learning_user"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/learnings/{learning_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Learning
+         * @description Retrieve a single learning record by its ID.
+         */
+        get: operations["get_learning"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete Learning
+         * @description Permanently delete a learning record by its ID. Records with no owner (`user_id IS NULL` — shared agent/team/session/entity learnings) may only be deleted by an admin.
+         */
+        delete: operations["delete_learning"];
+        options?: never;
+        head?: never;
+        /**
+         * Update Learning
+         * @description Update a learning record. Only `content` and `metadata` may be modified; identity fields (user_id, agent_id, team_id, etc.) are immutable. Provided fields fully replace the existing values. Records with no owner (`user_id IS NULL` — shared agent/team/session/entity learnings) are readable by any caller but may only be modified by an admin.
+         */
+        patch: operations["update_learning"];
+        trace?: never;
+    };
     "/eval-runs": {
         parameters: {
             query?: never;
@@ -1002,9 +1742,29 @@ export interface paths {
         put?: never;
         /**
          * Refresh Metrics
-         * @description Manually trigger recalculation of system metrics from raw data. This operation analyzes system activity logs and regenerates aggregated metrics. Useful for ensuring metrics are up-to-date or after system maintenance.
+         * @description Manually trigger recalculation of system metrics from raw data. This operation analyzes system activity logs and regenerates aggregated metrics. Useful for ensuring metrics are up-to-date or after system maintenance. By default the refresh runs synchronously and returns the refreshed metrics. Pass background=true to run the refresh in the background instead: the endpoint returns 202 Accepted immediately and GET /metrics can be polled for results. If a background refresh is already in progress for the target database, returns status 'already_running' without starting a new one.
          */
         post: operations["refresh_metrics"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/metrics/refresh/status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Metrics Refresh Status
+         * @description Get the status of the most recent metrics refresh for the target database. Returns 'running' while a refresh is in progress, then 'completed' or 'failed' with the finish timestamp — the state updates even when a refresh completes without writing new data. Returns 'idle' if no refresh has been triggered since this server process started. For remote databases the status is fetched from the remote AgentOS. Intended for polling after starting a background refresh via POST /metrics/refresh?background=true.
+         */
+        get: operations["get_metrics_refresh_status"];
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -1479,6 +2239,26 @@ export interface paths {
         patch: operations["update_component"];
         trace?: never;
     };
+    "/components/{component_id}/restore": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore Component
+         * @description Restore an archived (soft-deleted) component by ID.
+         */
+        post: operations["restore_component"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/components/{component_id}/configs": {
         parameters: {
             query?: never;
@@ -1779,6 +2559,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/service-accounts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Service Accounts
+         * @description List service accounts. Returns metadata and display prefixes only - never hashes or plaintext.
+         */
+        get: operations["list_service_accounts_service_accounts_get"];
+        put?: never;
+        /**
+         * Create Service Account
+         * @description Mint a service account token. The plaintext token is returned exactly once.
+         */
+        post: operations["create_service_account_service_accounts_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/service-accounts/{service_account_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Revoke Service Account
+         * @description Revoke a service account. Idempotent.
+         *
+         *     Takes effect immediately on this worker (the local verification cache entry is
+         *     evicted) and within the cache TTL on other workers.
+         */
+        delete: operations["revoke_service_account_service_accounts__service_account_id__delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/registry": {
         parameters: {
             query?: never;
@@ -1797,6 +2624,66 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/models": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Available Models
+         * @description Retrieve every unique model this OS instance can run: models used by agents and teams (team members included) plus the configured model catalog.
+         */
+        get: operations["get_models"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/agents/{agent_id}/model": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Set Agent Model
+         * @description Switch a code-defined agent's model at runtime. Takes effect on the next run; does not persist across restarts.
+         */
+        patch: operations["set_agent_model"];
+        trace?: never;
+    };
+    "/teams/{team_id}/model": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Set Team Model
+         * @description Switch a team leader's model at runtime, or a member's via member_id. Takes effect on the next run; does not persist across restarts.
+         */
+        patch: operations["set_team_model"];
         trace?: never;
     };
 }
@@ -1827,6 +2714,8 @@ export interface components {
             is_default: boolean;
             /** Is Active */
             is_active: boolean;
+            /** Memory Namespace */
+            memory_namespace?: string | null;
             /** Created At */
             created_at: unknown;
             /** Updated At */
@@ -1848,6 +2737,11 @@ export interface components {
             description?: string | null;
             /** Role */
             role?: string | null;
+            /**
+             * Is Factory
+             * @default false
+             */
+            is_factory: boolean;
             model?: components["schemas"]["ModelResponse"] | null;
             /** Tools */
             tools?: {
@@ -1897,6 +2791,10 @@ export interface components {
             } | null;
             /** Input Schema */
             input_schema?: {
+                [key: string]: unknown;
+            } | null;
+            /** Factory Input Schema */
+            factory_input_schema?: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -2016,6 +2914,86 @@ export interface components {
              * @description Database identifier
              */
             db_id?: string | null;
+            /** @description Model used by the agent */
+            model?: components["schemas"]["Model"] | null;
+            /**
+             * Metadata
+             * @description Additional metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /**
+         * ApplyAgentRequest
+         * @description Friendly agent manifest. All fields optional so a sparse ``update`` can
+         *     use ``model_fields_set`` to touch only what the caller provided.
+         *
+         *     ``extra="forbid"`` so an unknown/typo'd key (e.g. ``instructionz``) is
+         *     rejected with a 422 rather than silently dropped — the CLI catches this
+         *     client-side first, this guards every other caller.
+         */
+        ApplyAgentRequest: {
+            /**
+             * Kind
+             * @default Agent
+             */
+            kind: string;
+            /** Id */
+            id?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Description */
+            description?: string | null;
+            /** Model */
+            model?: string | null;
+            /** Db */
+            db?: string | null;
+            /** Knowledge */
+            knowledge?: string | null;
+            /** Stage */
+            stage?: string | null;
+            /** Instructions */
+            instructions?: string | null;
+            /** Toolsets */
+            toolsets?: string[] | null;
+            /** Ibmitools */
+            ibmiTools?: {
+                [key: string]: unknown;
+            }[] | null;
+            /** Options */
+            options?: {
+                [key: string]: unknown;
+            } | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Mode
+             * @default apply
+             */
+            mode: string;
+        };
+        /** ApplyAgentResponse */
+        ApplyAgentResponse: {
+            /** Component Id */
+            component_id: string;
+            /** Stage */
+            stage: string;
+            /** Version */
+            version?: number | null;
+            /** Action */
+            action: string;
+            /** Config Keys */
+            config_keys?: string[];
+            /** Stripped Overrides */
+            stripped_overrides?: string[];
+            /**
+             * Tools Written
+             * @default 0
+             */
+            tools_written: number;
         };
         /**
          * ApprovalCountResponse
@@ -2119,23 +3097,47 @@ export interface components {
             resolved_by?: string | null;
         };
         /**
+         * Artifact
+         * @description Represents a file, data structure, or other resource generated by an agent during a task.
+         */
+        Artifact: {
+            /** Artifactid */
+            artifactId: string;
+            /** Description */
+            description?: string | null;
+            /** Extensions */
+            extensions?: string[] | null;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Name */
+            name?: string | null;
+            /** Parts */
+            parts: components["schemas"]["Part"][];
+        };
+        /**
          * BadRequestResponse
          * @example {
-         *       "detail": "Bad request",
-         *       "error_code": "BAD_REQUEST"
+         *       "detail": "Bad request"
          *     }
          */
         BadRequestResponse: {
             /**
              * Detail
-             * @description Error detail message
+             * @description Human-readable error message
              */
             detail: string;
             /**
-             * Error Code
-             * @description Error code for categorization
+             * Error Id
+             * @description Stable identifier for the specific error, present only when the error carries one
              */
-            error_code?: string | null;
+            error_id?: string | null;
+            /**
+             * Error Type
+             * @description Category of the error, present only when the error carries one
+             */
+            error_type?: string | null;
         };
         /** Body_continue_agent_run */
         Body_continue_agent_run: {
@@ -2145,6 +3147,39 @@ export interface components {
              * @default
              */
             tools: string;
+            /**
+             * Input
+             * @description Optional new user-message text to append to the run before resuming. Use for continuing a COMPLETED run with a follow-up, or adding context to a RUNNING/ERROR resume.
+             */
+            input?: string | null;
+            /**
+             * Continue From
+             * @description Continuation boundary. Use 'end', 'last_user', or a numeric message index.
+             * @default end
+             */
+            continue_from: string;
+            /**
+             * Fork
+             * @description When true, clone the run with a new ``run_id`` before resuming. The original is untouched; the clone becomes a sibling within the same session, with ``forked_from_run_id`` set.
+             * @default false
+             */
+            fork: boolean;
+            /**
+             * Regenerate
+             * @description Sugar: regenerate the last response of this run. Auto-computes ``continue_from='last_user'`` to land just after the last user message. Pair with ``additional_instructions`` to steer the new output. By default the original response is hidden from history (replaced); pass ``replace_original=false`` to keep both the original and the regenerated response visible side by side.
+             * @default false
+             */
+            regenerate: boolean;
+            /**
+             * Replace Original
+             * @description Only valid with ``regenerate=true``. Controls history visibility of the original response; the original run is always retained in storage. Defaults to true: the original is marked REGENERATED and hidden from history so the new response replaces it. Pass false to keep both the original and regenerated responses visible.
+             */
+            replace_original?: boolean | null;
+            /**
+             * Additional Instructions
+             * @description Only valid with ``regenerate=true``: extra guidance appended as a user message before re-generation. Friendly alias for ``input``.
+             */
+            additional_instructions?: string | null;
             /**
              * Session Id
              * @description Session ID for the paused run
@@ -2161,6 +3196,92 @@ export interface components {
              * @default true
              */
             stream: boolean;
+            /**
+             * Background
+             * @description Run continue in background (survives client disconnect). Requires database. Use /resume to reconnect.
+             * @default false
+             */
+            background: boolean;
+        };
+        /** Body_continue_team_run */
+        Body_continue_team_run: {
+            /**
+             * Requirements
+             * @default
+             */
+            requirements: string;
+            /** Input */
+            input?: string | null;
+            /**
+             * Continue From
+             * @description Continuation boundary. Use 'end', 'last_user', or a numeric message index.
+             * @default end
+             */
+            continue_from: string;
+            /**
+             * Fork
+             * @default false
+             */
+            fork: boolean;
+            /**
+             * Regenerate
+             * @default false
+             */
+            regenerate: boolean;
+            /** Replace Original */
+            replace_original?: boolean | null;
+            /** Additional Instructions */
+            additional_instructions?: string | null;
+            /** Session Id */
+            session_id?: string | null;
+            /** User Id */
+            user_id?: string | null;
+            /**
+             * Stream
+             * @default true
+             */
+            stream: boolean;
+            /**
+             * Background
+             * @default false
+             */
+            background: boolean;
+        };
+        /** Body_continue_workflow_run */
+        Body_continue_workflow_run: {
+            /**
+             * Step Requirements
+             * @description JSON string of step requirement objects with resolution status
+             * @default
+             */
+            step_requirements: string;
+            /**
+             * Session Id
+             * @description Session ID for the paused run
+             */
+            session_id?: string | null;
+            /**
+             * User Id
+             * @description User identifier for tracking and personalization
+             */
+            user_id?: string | null;
+            /**
+             * Stream
+             * @description Enable streaming responses via Server-Sent Events (SSE)
+             * @default true
+             */
+            stream: boolean;
+            /**
+             * Background
+             * @description Continue in background (survives client disconnect). Requires database. Use /resume to reconnect.
+             * @default false
+             */
+            background: boolean;
+            /**
+             * Factory Input
+             * @description JSON object with factory-specific parameters for dynamic workflow reconstruction
+             */
+            factory_input?: string | null;
         };
         /** Body_create_agent_run */
         Body_create_agent_run: {
@@ -2191,16 +3312,26 @@ export interface components {
              */
             files?: string[] | null;
             /**
+             * Files Metadata
+             * @description JSON array of per-file metadata objects, matched to files[] by position
+             */
+            files_metadata?: string | null;
+            /**
              * Version
              * @description Agent version to use for this run
              */
-            version?: string | null;
+            version?: number | null;
             /**
              * Background
              * @description Run in background and return immediately with run metadata (requires database)
              * @default false
              */
             background: boolean;
+            /**
+             * Factory Input
+             * @description JSON object with factory-specific parameters for dynamic agent construction
+             */
+            factory_input?: string | null;
         };
         /** Body_create_team_run */
         Body_create_team_run: {
@@ -2237,6 +3368,11 @@ export interface components {
              */
             files?: string[] | null;
             /**
+             * Files Metadata
+             * @description JSON array of per-file metadata objects, matched to files[] by position
+             */
+            files_metadata?: string | null;
+            /**
              * Version
              * @description Team version to use for this run
              */
@@ -2247,6 +3383,11 @@ export interface components {
              * @default false
              */
             background: boolean;
+            /**
+             * Factory Input
+             * @description JSON object with factory-specific parameters for dynamic team construction
+             */
+            factory_input?: string | null;
         };
         /** Body_create_workflow_run */
         Body_create_workflow_run: {
@@ -2262,6 +3403,12 @@ export interface components {
              */
             stream: boolean;
             /**
+             * Background
+             * @description Run workflow in background (survives client disconnect). Requires database. Use /resume to reconnect.
+             * @default false
+             */
+            background: boolean;
+            /**
              * Session Id
              * @description Session ID for conversation continuity. If not provided, a new session is created
              */
@@ -2276,6 +3423,11 @@ export interface components {
              * @description Workflow version to use for this run
              */
             version?: number | null;
+            /**
+             * Factory Input
+             * @description JSON object with factory-specific parameters for dynamic workflow construction
+             */
+            factory_input?: string | null;
         };
         /** Body_rename_session */
         Body_rename_session: {
@@ -2284,6 +3436,45 @@ export interface components {
              * @description New name for the session
              */
             session_name: string;
+        };
+        /** Body_resume_agent_run_stream */
+        Body_resume_agent_run_stream: {
+            /**
+             * Last Event Index
+             * @description Index of last event received by client (0-based)
+             */
+            last_event_index?: number | null;
+            /**
+             * Session Id
+             * @description Session ID for database fallback
+             */
+            session_id?: string | null;
+        };
+        /** Body_resume_team_run_stream */
+        Body_resume_team_run_stream: {
+            /**
+             * Last Event Index
+             * @description Index of last event received by client (0-based)
+             */
+            last_event_index?: number | null;
+            /**
+             * Session Id
+             * @description Session ID for database fallback
+             */
+            session_id?: string | null;
+        };
+        /** Body_resume_workflow_run_stream */
+        Body_resume_workflow_run_stream: {
+            /**
+             * Last Event Index
+             * @description Index of last event received by client (0-based)
+             */
+            last_event_index?: number | null;
+            /**
+             * Session Id
+             * @description Session ID for database fallback
+             */
+            session_id?: string | null;
         };
         /** Body_update_content */
         Body_update_content: {
@@ -2373,6 +3564,11 @@ export interface components {
              * @description Path to file or folder in the remote source
              */
             path: string;
+            /**
+             * Source Params
+             * @description JSON object of per-request parameters forwarded to the source's factory. Used for provider-specific routing that shouldn't be baked into the config. Currently supported keys: GitHub accepts 'repo' ('owner/repo'), letting one configured GitHub source serve multiple repositories the credentials can access.
+             */
+            source_params?: string | null;
             /**
              * Name
              * @description Content name (auto-generated if not provided)
@@ -2509,6 +3705,38 @@ export interface components {
              */
             set_current: boolean;
         };
+        /**
+         * ComponentDeleteRequest
+         * @description Body for delete. Optional: a bodyless DELETE keeps working.
+         *
+         *     Delete also accepts the guard as an ``expected_current_version`` query
+         *     param; this shape exists so the guard reads the same as on every other
+         *     guarded component route instead of being silently ignored here.
+         */
+        ComponentDeleteRequest: {
+            /** @description Optional compare-and-set guard */
+            guard?: components["schemas"]["ComponentGuard"] | null;
+        };
+        /**
+         * ComponentGuard
+         * @description Optional compare-and-set guard for component writes.
+         *
+         *     When present, each non-None field is checked against the stored state and
+         *     the write is rejected with 409 on mismatch. None fields skip that half of
+         *     the check; omitting the guard keeps the write last-writer-wins.
+         */
+        ComponentGuard: {
+            /**
+             * Latest Version
+             * @description Expected latest config version
+             */
+            latest_version?: number | null;
+            /**
+             * Current Version
+             * @description Expected current (published) version; 0 expects the component to have none yet
+             */
+            current_version?: number | null;
+        };
         /** ComponentResponse */
         ComponentResponse: {
             /** Component Id */
@@ -2516,6 +3744,8 @@ export interface components {
             component_type: components["schemas"]["ComponentType"];
             /** Name */
             name?: string | null;
+            /** User Id */
+            user_id?: string | null;
             /** Description */
             description?: string | null;
             /** Current Version */
@@ -2528,6 +3758,8 @@ export interface components {
             created_at: number;
             /** Updated At */
             updated_at?: number | null;
+            /** Deleted At */
+            deleted_at?: number | null;
         };
         /**
          * ComponentType
@@ -2548,6 +3780,7 @@ export interface components {
             } | null;
             /** Current Version */
             current_version?: number | null;
+            guard?: components["schemas"]["ComponentGuard"] | null;
         };
         /** ConfigCreate */
         ConfigCreate: {
@@ -2592,6 +3825,8 @@ export interface components {
              * @default true
              */
             set_current: boolean;
+            /** @description Optional compare-and-set guard */
+            guard?: components["schemas"]["ComponentGuard"] | null;
         };
         /**
          * ConfigResponse
@@ -2615,9 +3850,9 @@ export interface components {
             description?: string | null;
             /**
              * Available Models
-             * @description List of available models
+             * @description Unique models (id + provider) in use by agents and teams in this OS
              */
-            available_models?: string[] | null;
+            available_models?: components["schemas"]["Model"][];
             /**
              * Os Database
              * @description ID of the database used for the OS instance
@@ -2630,12 +3865,21 @@ export interface components {
             databases: string[];
             /** @description Chat configuration */
             chat?: components["schemas"]["ChatConfig"] | null;
+            /**
+             * Manifest
+             * @description Per-entity UI metadata keyed by agent/team/workflow id
+             */
+            manifest?: {
+                [key: string]: components["schemas"]["Manifest"];
+            } | null;
             /** @description Session configuration */
             session?: components["schemas"]["SessionConfig"] | null;
             /** @description Metrics configuration */
             metrics?: components["schemas"]["MetricsConfig"] | null;
             /** @description Memory configuration */
             memory?: components["schemas"]["MemoryConfig"] | null;
+            /** @description Learning configuration */
+            learning?: components["schemas"]["LearningConfig"] | null;
             /** @description Knowledge configuration */
             knowledge?: components["schemas"]["KnowledgeConfig"] | null;
             /** @description Evaluations configuration */
@@ -2701,6 +3945,20 @@ export interface components {
              * @description Configured remote content sources (S3, GCS, SharePoint, GitHub)
              */
             remote_content_sources?: components["schemas"]["RemoteContentSourceSchema"][] | null;
+            /**
+             * Unavailable Readers
+             * @description Readers that are not usable in this install, and the packages they need
+             */
+            unavailable_readers?: {
+                [key: string]: components["schemas"]["UnavailableReaderSchema"];
+            } | null;
+            /**
+             * Unavailable Chunkers
+             * @description Chunking strategies that are not usable in this install, and the packages they need
+             */
+            unavailable_chunkers?: {
+                [key: string]: components["schemas"]["UnavailableChunkerSchema"];
+            } | null;
         };
         /** ConfigUpdate */
         ConfigUpdate: {
@@ -2718,6 +3976,7 @@ export interface components {
             links?: {
                 [key: string]: unknown;
             }[] | null;
+            guard?: components["schemas"]["ComponentGuard"] | null;
         };
         /** ConnectionResponse */
         ConnectionResponse: {
@@ -2743,6 +4002,8 @@ export interface components {
             is_default: boolean;
             /** Is Active */
             is_active: boolean;
+            /** Memory Namespace */
+            memory_namespace?: string | null;
             /** Created At */
             created_at: unknown;
             /** Updated At */
@@ -2871,6 +4132,11 @@ export interface components {
              * @default false
              */
             is_default: boolean;
+            /**
+             * Memory Namespace
+             * @description Optional memory/learning namespace. Omit for per-system isolation (the default); set the same value on two connections to share a brain across them.
+             */
+            memory_namespace?: string | null;
         };
         /** CreateKeyRequest */
         CreateKeyRequest: {
@@ -2974,11 +4240,39 @@ export interface components {
              */
             workflow_id?: string | null;
         };
+        /**
+         * DataPart
+         * @description Represents a structured data segment (e.g., JSON) within a message or artifact.
+         */
+        DataPart: {
+            /** Data */
+            data: {
+                [key: string]: unknown;
+            };
+            /**
+             * Kind
+             * @default data
+             * @constant
+             */
+            kind: "data";
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
         /** DatabaseConfig[EvalsDomainConfig] */
         DatabaseConfig_EvalsDomainConfig_: {
             /** Db Id */
             db_id: string;
             domain_config?: components["schemas"]["EvalsDomainConfig"] | null;
+            /** Tables */
+            tables?: string[] | null;
+        };
+        /** DatabaseConfig[LearningDomainConfig] */
+        DatabaseConfig_LearningDomainConfig_: {
+            /** Db Id */
+            db_id: string;
+            domain_config?: components["schemas"]["LearningDomainConfig"] | null;
             /** Tables */
             tables?: string[] | null;
         };
@@ -3214,6 +4508,23 @@ export interface components {
              * @description Expected tool calls for reliability evaluation
              */
             expected_tool_calls?: string[] | null;
+            /**
+             * Allow Additional Tool Calls
+             * @description When True, tool calls not in expected_tool_calls are allowed (subset matching)
+             * @default false
+             */
+            allow_additional_tool_calls: boolean;
+            /**
+             * Expected Tool Call Arguments
+             * @description Expected arguments for specific tool calls, e.g. {"tool_name": {"arg_name": "expected_value"}} or {"tool_name": [{"arg_name": "val1"}, {"arg_name": "val2"}]}
+             */
+            expected_tool_call_arguments?: {
+                [key: string]: {
+                    [key: string]: unknown;
+                } | {
+                    [key: string]: unknown;
+                }[];
+            } | null;
         };
         /** EvalSchema */
         EvalSchema: {
@@ -3257,6 +4568,11 @@ export interface components {
              * @description Name of the evaluated component
              */
             evaluated_component_name?: string | null;
+            /**
+             * User Id
+             * @description Owner of the evaluation run
+             */
+            user_id?: string | null;
             /** @description Type of evaluation (accuracy, performance, or reliability) */
             eval_type: components["schemas"]["EvalType"];
             /**
@@ -3296,8 +4612,6 @@ export interface components {
         EvalsConfig: {
             /** Display Name */
             display_name?: string | null;
-            /** Available Models */
-            available_models?: string[] | null;
             /** Dbs */
             dbs?: components["schemas"]["DatabaseConfig_EvalsDomainConfig_"][] | null;
         };
@@ -3308,8 +4622,49 @@ export interface components {
         EvalsDomainConfig: {
             /** Display Name */
             display_name?: string | null;
-            /** Available Models */
-            available_models?: string[] | null;
+        };
+        /**
+         * FilePart
+         * @description Represents a file segment within a message or artifact. The file content can be
+         *     provided either directly as bytes or as a URI.
+         */
+        FilePart: {
+            /** File */
+            file: components["schemas"]["FileWithBytes"] | components["schemas"]["FileWithUri"];
+            /**
+             * Kind
+             * @default file
+             * @constant
+             */
+            kind: "file";
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /**
+         * FileWithBytes
+         * @description Represents a file with its content provided directly as a base64-encoded string.
+         */
+        FileWithBytes: {
+            /** Bytes */
+            bytes: string;
+            /** Mimetype */
+            mimeType?: string | null;
+            /** Name */
+            name?: string | null;
+        };
+        /**
+         * FileWithUri
+         * @description Represents a file with its content located at a specific URI.
+         */
+        FileWithUri: {
+            /** Mimetype */
+            mimeType?: string | null;
+            /** Name */
+            name?: string | null;
+            /** Uri */
+            uri: string;
         };
         /**
          * FilterFieldSchema
@@ -3387,6 +4742,59 @@ export interface components {
              */
             instantiated_at: string;
         };
+        /**
+         * InfoResponse
+         * @description Response schema for the /info endpoint returning lightweight OS metadata.
+         */
+        InfoResponse: {
+            /**
+             * Os Id
+             * @description Unique identifier for the OS instance
+             */
+            os_id: string;
+            /**
+             * Name
+             * @description Name of the OS instance
+             */
+            name?: string | null;
+            /**
+             * Os Version
+             * @description Version of this AgentOS instance
+             */
+            os_version: string;
+            /**
+             * Agno Version
+             * @description Version of the agno framework
+             */
+            agno_version: string;
+            /**
+             * Agent Count
+             * @description Number of agents registered in the OS
+             * @default 0
+             */
+            agent_count: number;
+            /**
+             * Team Count
+             * @description Number of teams registered in the OS
+             * @default 0
+             */
+            team_count: number;
+            /**
+             * Workflow Count
+             * @description Number of workflows registered in the OS
+             * @default 0
+             */
+            workflow_count: number;
+            /** @description MCP server availability for this OS instance */
+            mcp?: components["schemas"]["McpInfo"];
+            /**
+             * Auth Mode
+             * @description Authentication mode enforced on the REST/WS plane of this OS instance. MCP OAuth, when enabled, is described separately under `mcp.oauth`.
+             * @default none
+             * @enum {string}
+             */
+            auth_mode: "none" | "security_key" | "jwt";
+        };
         /** InterfaceResponse */
         InterfaceResponse: {
             /**
@@ -3408,21 +4816,25 @@ export interface components {
         /**
          * InternalServerErrorResponse
          * @example {
-         *       "detail": "Internal server error",
-         *       "error_code": "INTERNAL_SERVER_ERROR"
+         *       "detail": "Internal server error"
          *     }
          */
         InternalServerErrorResponse: {
             /**
              * Detail
-             * @description Error detail message
+             * @description Human-readable error message
              */
             detail: string;
             /**
-             * Error Code
-             * @description Error code for categorization
+             * Error Id
+             * @description Stable identifier for the specific error, present only when the error carries one
              */
-            error_code?: string | null;
+            error_id?: string | null;
+            /**
+             * Error Type
+             * @description Category of the error, present only when the error carries one
+             */
+            error_type?: string | null;
         };
         /** KeyResponse */
         KeyResponse: {
@@ -3506,6 +4918,256 @@ export interface components {
             /** Table */
             table: string;
         };
+        /**
+         * LearningConfig
+         * @description Configuration for the Learning domain of the AgentOS
+         */
+        LearningConfig: {
+            /** Display Name */
+            display_name?: string | null;
+            /** Dbs */
+            dbs?: components["schemas"]["DatabaseConfig_LearningDomainConfig_"][] | null;
+        };
+        /**
+         * LearningCreate
+         * @description Request body for creating a learning record.
+         */
+        LearningCreate: {
+            /**
+             * Learning Type
+             * @description Type of learning (e.g. 'user_profile', 'entity_memory')
+             */
+            learning_type: string;
+            /**
+             * Content
+             * @description The learning content payload
+             */
+            content: {
+                [key: string]: unknown;
+            };
+            /**
+             * Namespace
+             * @description Namespace for scoping ('user', 'global', or custom)
+             */
+            namespace?: string | null;
+            /**
+             * User Id
+             * @description Associated user ID. When the request is authenticated, must match the JWT subject or be omitted/null (which creates a global / non-user-scoped record).
+             */
+            user_id?: string | null;
+            /**
+             * Agent Id
+             * @description Associated agent ID
+             */
+            agent_id?: string | null;
+            /**
+             * Team Id
+             * @description Associated team ID
+             */
+            team_id?: string | null;
+            /**
+             * Session Id
+             * @description Associated session ID
+             */
+            session_id?: string | null;
+            /**
+             * Entity Id
+             * @description Associated entity ID
+             */
+            entity_id?: string | null;
+            /**
+             * Entity Type
+             * @description Entity type
+             */
+            entity_type?: string | null;
+            /**
+             * Metadata
+             * @description Optional metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /**
+         * LearningDomainConfig
+         * @description Configuration for the Learning domain of the AgentOS
+         */
+        LearningDomainConfig: {
+            /** Display Name */
+            display_name?: string | null;
+        };
+        /**
+         * LearningResponse
+         * @description A single learning record as returned by the API.
+         */
+        LearningResponse: {
+            /**
+             * Learning Id
+             * @description Unique identifier for the learning record
+             */
+            learning_id: string;
+            /**
+             * Learning Type
+             * @description Type of learning (e.g. 'user_profile', 'entity_memory')
+             */
+            learning_type: string;
+            /**
+             * Namespace
+             * @description Namespace for scoping ('user', 'global', or custom)
+             */
+            namespace?: string | null;
+            /**
+             * User Id
+             * @description Associated user ID
+             */
+            user_id?: string | null;
+            /**
+             * Agent Id
+             * @description Associated agent ID
+             */
+            agent_id?: string | null;
+            /**
+             * Team Id
+             * @description Associated team ID
+             */
+            team_id?: string | null;
+            /**
+             * Session Id
+             * @description Associated session ID
+             */
+            session_id?: string | null;
+            /**
+             * Entity Id
+             * @description Associated entity ID (for entity-specific learnings)
+             */
+            entity_id?: string | null;
+            /**
+             * Entity Type
+             * @description Entity type (e.g. 'person', 'company')
+             */
+            entity_type?: string | null;
+            /**
+             * Content
+             * @description The learning content payload
+             */
+            content?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Metadata
+             * @description Optional metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Created At
+             * @description Creation timestamp (Unix epoch seconds)
+             */
+            created_at?: number | null;
+            /**
+             * Updated At
+             * @description Last update timestamp (Unix epoch seconds)
+             */
+            updated_at?: number | null;
+        };
+        /**
+         * LearningUpdate
+         * @description Request body for updating a learning record. Identity fields are immutable.
+         */
+        LearningUpdate: {
+            /**
+             * Content
+             * @description Replacement content payload
+             */
+            content?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Metadata
+             * @description Replacement metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /**
+         * LearningUserStats
+         * @description A user that owns learning records, with their most recent activity.
+         *
+         *     Used as a lightweight index for the per-user view: list users here, then drill into a
+         *     single user's records via ``GET /learnings?user_id=...``. No per-user count is returned
+         *     -- the user-scoped stores (``user_profile``, ``user_memory``) keep a single record per
+         *     user, so a record count would always be 1; the actual memory count lives in that
+         *     record's ``content``.
+         */
+        LearningUserStats: {
+            /**
+             * User Id
+             * @description The user ID
+             */
+            user_id: string;
+            /**
+             * Last Learning Updated At
+             * @description Most recent learning update for this user (Unix epoch seconds)
+             */
+            last_learning_updated_at?: number | null;
+        };
+        /**
+         * Manifest
+         * @description OS-level UI metadata for an agent/team/workflow.
+         *
+         *     Fields here are AgentOS UI metadata only. ``description`` is unrelated to
+         *     ``Agent.description`` / ``Team.description`` / ``Workflow.description``,
+         *     which are sent to the model.
+         *
+         *     Rendering surfaces:
+         *     - ``description``, ``labels``: home/landing card
+         *     - ``quick_prompts``: chat page
+         */
+        Manifest: {
+            /** Description */
+            description?: string | null;
+            /** Labels */
+            labels?: string[] | null;
+            /** Quick Prompts */
+            quick_prompts?: string[] | null;
+        };
+        /**
+         * McpInfo
+         * @description MCP server availability for the /info endpoint.
+         */
+        McpInfo: {
+            /**
+             * Enabled
+             * @description Whether the MCP server is enabled on this OS instance
+             * @default false
+             */
+            enabled: boolean;
+            /**
+             * Path
+             * @description Path where the MCP server is mounted, null when disabled
+             */
+            path?: string | null;
+            /** @description OAuth discovery details when the MCP endpoint is OAuth-protected, null otherwise */
+            oauth?: components["schemas"]["McpOAuthInfo"] | null;
+        };
+        /**
+         * McpOAuthInfo
+         * @description OAuth discovery details for an MCP endpoint protected by ``AgentOS(mcp_auth=...)``.
+         */
+        McpOAuthInfo: {
+            /**
+             * Authorization Servers
+             * @description Issuer URL(s) of the authorization server(s) protecting the MCP endpoint
+             */
+            authorization_servers?: string[] | null;
+            /**
+             * Resource
+             * @description RFC 9728 resource URL advertised for the MCP endpoint
+             */
+            resource?: string | null;
+        };
         /** MeResponse */
         MeResponse: {
             /**
@@ -3550,6 +5212,35 @@ export interface components {
             display_name?: string | null;
         };
         /**
+         * Message
+         * @description Represents a single message in the conversation between a user and an agent.
+         */
+        Message: {
+            /** Contextid */
+            contextId?: string | null;
+            /** Extensions */
+            extensions?: string[] | null;
+            /**
+             * Kind
+             * @default message
+             * @constant
+             */
+            kind: "message";
+            /** Messageid */
+            messageId: string;
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Parts */
+            parts: components["schemas"]["Part"][];
+            /** Referencetaskids */
+            referenceTaskIds?: string[] | null;
+            role: components["schemas"]["Role"];
+            /** Taskid */
+            taskId?: string | null;
+        };
+        /**
          * Meta
          * @description Inline metadata schema for pagination.
          */
@@ -3584,6 +5275,42 @@ export interface components {
         MetricsDomainConfig: {
             /** Display Name */
             display_name?: string | null;
+        };
+        /** MetricsRefreshResponse */
+        MetricsRefreshResponse: {
+            /**
+             * Status
+             * @description Status of the refresh request
+             */
+            status: string;
+            /**
+             * Message
+             * @description Additional details
+             */
+            message?: string | null;
+        };
+        /** MetricsRefreshStatusResponse */
+        MetricsRefreshStatusResponse: {
+            /**
+             * Status
+             * @description Refresh status: 'idle', 'running', 'completed' or 'failed'
+             */
+            status: string;
+            /**
+             * Started At
+             * @description When the most recent refresh started
+             */
+            started_at?: string | null;
+            /**
+             * Finished At
+             * @description When the most recent refresh finished
+             */
+            finished_at?: string | null;
+            /**
+             * Error
+             * @description Error message if the most recent refresh failed
+             */
+            error?: string | null;
         };
         /** MetricsResponse */
         MetricsResponse: {
@@ -3632,21 +5359,25 @@ export interface components {
         /**
          * NotFoundResponse
          * @example {
-         *       "detail": "Not found",
-         *       "error_code": "NOT_FOUND"
+         *       "detail": "Not found"
          *     }
          */
         NotFoundResponse: {
             /**
              * Detail
-             * @description Error detail message
+             * @description Human-readable error message
              */
             detail: string;
             /**
-             * Error Code
-             * @description Error code for categorization
+             * Error Id
+             * @description Stable identifier for the specific error, present only when the error carries one
              */
-            error_code?: string | null;
+            error_id?: string | null;
+            /**
+             * Error Type
+             * @description Category of the error, present only when the error carries one
+             */
+            error_type?: string | null;
         };
         /**
          * OptimizeMemoriesRequest
@@ -3751,6 +5482,26 @@ export interface components {
             /** @description Pagination metadata */
             meta: components["schemas"]["PaginationInfo"];
         };
+        /** PaginatedResponse[LearningResponse] */
+        PaginatedResponse_LearningResponse_: {
+            /**
+             * Data
+             * @description List of items for the current page
+             */
+            data: components["schemas"]["LearningResponse"][];
+            /** @description Pagination metadata */
+            meta: components["schemas"]["PaginationInfo"];
+        };
+        /** PaginatedResponse[LearningUserStats] */
+        PaginatedResponse_LearningUserStats_: {
+            /**
+             * Data
+             * @description List of items for the current page
+             */
+            data: components["schemas"]["LearningUserStats"][];
+            /** @description Pagination metadata */
+            meta: components["schemas"]["PaginationInfo"];
+        };
         /** PaginatedResponse[RegistryContentResponse] */
         PaginatedResponse_RegistryContentResponse_: {
             /**
@@ -3778,6 +5529,16 @@ export interface components {
              * @description List of items for the current page
              */
             data: components["schemas"]["ScheduleRunResponse"][];
+            /** @description Pagination metadata */
+            meta: components["schemas"]["PaginationInfo"];
+        };
+        /** PaginatedResponse[ServiceAccountResponse] */
+        PaginatedResponse_ServiceAccountResponse_: {
+            /**
+             * Data
+             * @description List of items for the current page
+             */
+            data: components["schemas"]["ServiceAccountResponse"][];
             /** @description Pagination metadata */
             meta: components["schemas"]["PaginationInfo"];
         };
@@ -3855,7 +5616,7 @@ export interface components {
         PaginationInfo: {
             /**
              * Page
-             * @description Current page number (0-indexed)
+             * @description Current page number (1-indexed)
              * @default 0
              */
             page: number;
@@ -3884,6 +5645,8 @@ export interface components {
              */
             search_time_ms: number;
         };
+        /** Part */
+        Part: components["schemas"]["TextPart"] | components["schemas"]["FilePart"] | components["schemas"]["DataPart"];
         /** ReaderSchema */
         ReaderSchema: {
             /**
@@ -3906,6 +5669,18 @@ export interface components {
              * @description List of supported chunking strategies
              */
             chunkers?: string[] | null;
+            /**
+             * Content Types
+             * @description Content types this reader can read in this install
+             */
+            content_types?: string[] | null;
+            /**
+             * Unavailable Content Types
+             * @description Content types this reader supports but cannot read here, and the packages each needs
+             */
+            unavailable_content_types?: {
+                [key: string]: string[];
+            } | null;
         };
         /** RegistryContentResponse */
         RegistryContentResponse: {
@@ -3926,7 +5701,7 @@ export interface components {
          * @description Types of resources that can be stored in a registry.
          * @enum {string}
          */
-        RegistryResourceType: "tool" | "model" | "db" | "vector_db" | "schema" | "function" | "agent" | "team";
+        RegistryResourceType: "tool" | "model" | "db" | "vector_db" | "schema" | "function" | "agent" | "team" | "workflow" | "knowledge" | "memory_manager" | "session_summary_manager" | "learning";
         /**
          * RemoteContentSourceSchema
          * @description Schema for remote content source configuration.
@@ -3960,6 +5735,12 @@ export interface components {
              */
             prefix?: string | null;
         };
+        /**
+         * Role
+         * @description Identifies the sender of the message. `user` for the client, `agent` for the service.
+         * @enum {string}
+         */
+        Role: "agent" | "user";
         /** RunSchema */
         RunSchema: {
             /**
@@ -4124,13 +5905,38 @@ export interface components {
              * @description Followup suggestions generated after the run
              */
             followups?: string[] | null;
+            /**
+             * Forked From Run Id
+             * @description If this run was forked from another run, the source run's ID
+             */
+            forked_from_run_id?: string | null;
+            /**
+             * Forked From Message Index
+             * @description If this run was forked, the message index at which the source was truncated
+             */
+            forked_from_message_index?: number | null;
+            /**
+             * Forked From Session Id
+             * @description If this run was created via session branch, the source session's ID
+             */
+            forked_from_session_id?: string | null;
+            /**
+             * Regenerated From
+             * @description If this run was produced via regenerate=true, the source run's ID
+             */
+            regenerated_from?: string | null;
+            /**
+             * Last Checkpoint At Message Index
+             * @description Message index of the most recent mid-run checkpoint (checkpoint='tool-batch' runs)
+             */
+            last_checkpoint_at_message_index?: number | null;
         };
         /**
          * RunStatus
          * @description State of the main run response
          * @enum {string}
          */
-        RunStatus: "PENDING" | "RUNNING" | "COMPLETED" | "PAUSED" | "CANCELLED" | "ERROR";
+        RunStatus: "PENDING" | "RUNNING" | "COMPLETED" | "PAUSED" | "CANCELLED" | "ERROR" | "REGENERATED";
         /** ScheduleCreate */
         ScheduleCreate: {
             /** Name */
@@ -4175,6 +5981,8 @@ export interface components {
         ScheduleResponse: {
             /** Id */
             id: string;
+            /** User Id */
+            user_id?: string | null;
             /** Name */
             name: string;
             /** Description */
@@ -4201,6 +6009,14 @@ export interface components {
             enabled: boolean;
             /** Next Run At */
             next_run_at?: number | null;
+            /** Managed By */
+            managed_by?: string | null;
+            /** Target Type */
+            target_type?: string | null;
+            /** Target Id */
+            target_id?: string | null;
+            /** Disabled Reason */
+            disabled_reason?: string | null;
             /** Created At */
             created_at?: number | null;
             /** Updated At */
@@ -4212,6 +6028,8 @@ export interface components {
             id: string;
             /** Schedule Id */
             schedule_id: string;
+            /** User Id */
+            user_id?: string | null;
             /** Attempt */
             attempt: number;
             /** Triggered At */
@@ -4285,6 +6103,201 @@ export interface components {
             retry_delay_seconds?: number | null;
         };
         /**
+         * ScopeItem
+         * @description Write shape for one scope grant — the canonical RBAC payload for every scope-bearing API.
+         *
+         *     Endpoints that take scopes accept these objects only (a bare string is a validation
+         *     error). ``effect`` is constrained here so every consumer rejects typos at the model
+         *     layer; whether ``deny`` is *semantically* legal stays per-endpoint (roles support
+         *     deny rules, service-account tokens are pure grants and reject it).
+         */
+        ScopeItem: {
+            /**
+             * Scope
+             * @description Scope string, e.g. 'agents:*:run'
+             */
+            scope: string;
+            /**
+             * Effect
+             * @description 'allow' or 'deny'
+             * @default allow
+             * @enum {string}
+             */
+            effect: "allow" | "deny";
+        };
+        /**
+         * ScopeSchema
+         * @description Read shape for one scope — the parsed RBAC payload shared by every scope-bearing API.
+         *
+         *     Mirrors the cloud RBAC scope shape ({raw, namespace, sub_namespace, permission, value})
+         *     so a frontend renders scopes from any AgentOS API with one integration.
+         */
+        ScopeSchema: {
+            /**
+             * Id
+             * @description Scope id (always null here; kept for shape parity with the cloud RBAC API, which addresses scopes individually)
+             */
+            id?: string | null;
+            /**
+             * Raw
+             * @description Original scope string, e.g. 'agents:*:run'
+             */
+            raw: string;
+            /**
+             * Namespace
+             * @description Resource namespace, e.g. 'agents'
+             */
+            namespace: string;
+            /**
+             * Sub Namespace
+             * @description Specific resource id or wildcard '*'
+             */
+            sub_namespace?: string | null;
+            /**
+             * Permission
+             * @description Action, e.g. 'read' / 'run' / 'write'
+             */
+            permission: string;
+            /**
+             * Value
+             * @description 'allow' or 'deny'
+             * @default allow
+             */
+            value: string;
+        };
+        /**
+         * SendMessageSuccessResponse
+         * @description Represents a successful JSON-RPC response for the `message/send` method.
+         */
+        SendMessageSuccessResponse: {
+            /** Id */
+            id?: string | number | null;
+            /**
+             * Jsonrpc
+             * @default 2.0
+             * @constant
+             */
+            jsonrpc: "2.0";
+            /** Result */
+            result: components["schemas"]["Task"] | components["schemas"]["Message"];
+        };
+        /** ServiceAccountCreate */
+        ServiceAccountCreate: {
+            /**
+             * Name
+             * @description Machine identity name (lowercase slug), e.g. 'claude-code' or 'github-actions'
+             */
+            name: string;
+            /**
+             * Scopes
+             * @description Scopes granted to the token, as {scope, effect} objects (the shared RBAC write shape; token scopes are grants, so only effect='allow' is accepted). Defaults to run and read scopes: agents:run, teams:run, workflows:run, sessions:read
+             */
+            scopes?: components["schemas"]["ScopeItem"][] | null;
+            /**
+             * Expires In Days
+             * @description Days until the token expires (default: 90)
+             * @default 90
+             */
+            expires_in_days: number | null;
+            /**
+             * Never Expires
+             * @description Mint a non-expiring token. Must be set explicitly; overrides expires_in_days.
+             * @default false
+             */
+            never_expires: boolean;
+            /**
+             * Allow Privileged Scopes
+             * @description Required to grant privileged scopes: any write or delete action, the admin scope, or any service_accounts scope. Privileged tokens must be deliberate, never accidental.
+             * @default false
+             */
+            allow_privileged_scopes: boolean;
+        };
+        /**
+         * ServiceAccountCreateResponse
+         * @description Returned once, at creation. The token is never retrievable again.
+         */
+        ServiceAccountCreateResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /**
+             * Principal
+             * @description The user_id attached to runs made with this token, e.g. 'sa:claude-code'
+             */
+            principal: string;
+            /**
+             * User Id
+             * @description The user this account belongs to; None for workspace-level accounts. Distinct from created_by, which records who minted the token.
+             */
+            user_id?: string | null;
+            /**
+             * Token Prefix
+             * @description First characters of the token, for display only
+             */
+            token_prefix: string;
+            /**
+             * Scopes
+             * @description Scopes granted to the token, in the shared RBAC read shape
+             */
+            scopes?: components["schemas"]["ScopeSchema"][];
+            /** Created At */
+            created_at: number;
+            /** Expires At */
+            expires_at?: number | null;
+            /** Last Used At */
+            last_used_at?: number | null;
+            /** Revoked At */
+            revoked_at?: number | null;
+            /** Created By */
+            created_by?: string | null;
+            /**
+             * Token
+             * @description The plaintext token. Shown exactly once - store it securely now.
+             */
+            token: string;
+        };
+        /**
+         * ServiceAccountResponse
+         * @description Service account metadata. Never includes the token hash or plaintext.
+         */
+        ServiceAccountResponse: {
+            /** Id */
+            id: string;
+            /** Name */
+            name: string;
+            /**
+             * Principal
+             * @description The user_id attached to runs made with this token, e.g. 'sa:claude-code'
+             */
+            principal: string;
+            /**
+             * User Id
+             * @description The user this account belongs to; None for workspace-level accounts. Distinct from created_by, which records who minted the token.
+             */
+            user_id?: string | null;
+            /**
+             * Token Prefix
+             * @description First characters of the token, for display only
+             */
+            token_prefix: string;
+            /**
+             * Scopes
+             * @description Scopes granted to the token, in the shared RBAC read shape
+             */
+            scopes?: components["schemas"]["ScopeSchema"][];
+            /** Created At */
+            created_at: number;
+            /** Expires At */
+            expires_at?: number | null;
+            /** Last Used At */
+            last_used_at?: number | null;
+            /** Revoked At */
+            revoked_at?: number | null;
+            /** Created By */
+            created_by?: string | null;
+        };
+        /**
          * SessionConfig
          * @description Configuration for the Session domain of the AgentOS
          */
@@ -4331,12 +6344,91 @@ export interface components {
              * @description Timestamp when session was last updated
              */
             updated_at?: string | null;
+            /**
+             * Session Type
+             * @description Type of session: agent, team, or workflow
+             */
+            session_type?: string | null;
+            /**
+             * User Id
+             * @description User ID associated with the session
+             */
+            user_id?: string | null;
+            /**
+             * Agent Id
+             * @description Agent ID if this is an agent session
+             */
+            agent_id?: string | null;
+            /**
+             * Team Id
+             * @description Team ID if this is a team session
+             */
+            team_id?: string | null;
+            /**
+             * Workflow Id
+             * @description Workflow ID if this is a workflow session
+             */
+            workflow_id?: string | null;
+            /**
+             * Session Summary
+             * @description Summary of session interactions
+             */
+            session_summary?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Metrics
+             * @description Session metrics
+             */
+            metrics?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Total Tokens
+             * @description Total tokens used in this session
+             */
+            total_tokens?: number | null;
+            /**
+             * Metadata
+             * @description Additional metadata
+             */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
         };
         /**
          * SessionType
          * @enum {string}
          */
         SessionType: "agent" | "team" | "workflow";
+        /** SetAgentModelRequest */
+        SetAgentModelRequest: {
+            /** Model */
+            model: string;
+        };
+        /**
+         * SetCurrentRequest
+         * @description Body for set-current. Optional: an empty POST keeps working.
+         */
+        SetCurrentRequest: {
+            /** @description Optional compare-and-set guard */
+            guard?: components["schemas"]["ComponentGuard"] | null;
+        };
+        /** SetModelResponse */
+        SetModelResponse: {
+            /** Component Id */
+            component_id: string;
+            /** Member Id */
+            member_id?: string | null;
+            model: components["schemas"]["Model"];
+        };
+        /** SetTeamModelRequest */
+        SetTeamModelRequest: {
+            /** Model */
+            model: string;
+            /** Member Id */
+            member_id?: string | null;
+        };
         /**
          * SortOrder
          * @enum {string}
@@ -4428,6 +6520,50 @@ export interface components {
              */
             is_empty: boolean;
         };
+        /**
+         * Task
+         * @description Represents a single, stateful operation or conversation between a client and an agent.
+         */
+        Task: {
+            /** Artifacts */
+            artifacts?: components["schemas"]["Artifact"][] | null;
+            /** Contextid */
+            contextId: string;
+            /** History */
+            history?: components["schemas"]["Message"][] | null;
+            /** Id */
+            id: string;
+            /**
+             * Kind
+             * @default task
+             * @constant
+             */
+            kind: "task";
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            status: components["schemas"]["TaskStatus"];
+        };
+        /**
+         * TaskState
+         * @description Defines the lifecycle states of a Task.
+         * @enum {string}
+         */
+        TaskState: "submitted" | "working" | "input-required" | "completed" | "canceled" | "failed" | "rejected" | "auth-required" | "unknown";
+        /**
+         * TaskStatus
+         * @description Represents the status of a task at a specific point in time.
+         */
+        TaskStatus: {
+            message?: components["schemas"]["Message"] | null;
+            state: components["schemas"]["TaskState"];
+            /**
+             * Timestamp
+             * @example 2023-10-27T10:00:00Z
+             */
+            timestamp?: string | null;
+        };
         /** TeamResponse */
         TeamResponse: {
             /** Id */
@@ -4489,6 +6625,15 @@ export interface components {
             } | null;
             /** Input Schema */
             input_schema?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * Is Factory
+             * @default false
+             */
+            is_factory: boolean;
+            /** Factory Input Schema */
+            factory_input_schema?: {
                 [key: string]: unknown;
             } | null;
             /**
@@ -4660,6 +6805,31 @@ export interface components {
              * @description Followup suggestions generated after the run
              */
             followups?: string[] | null;
+            /**
+             * Forked From Run Id
+             * @description If this team run was forked from another run, the source run's ID
+             */
+            forked_from_run_id?: string | null;
+            /**
+             * Forked From Message Index
+             * @description If this team run was forked, the message index at which the source was truncated
+             */
+            forked_from_message_index?: number | null;
+            /**
+             * Forked From Session Id
+             * @description If this team run was created via session branch, the source session's ID
+             */
+            forked_from_session_id?: string | null;
+            /**
+             * Regenerated From
+             * @description If this team run was produced via regenerate=true, the source run's ID
+             */
+            regenerated_from?: string | null;
+            /**
+             * Last Checkpoint At Message Index
+             * @description Message index of the most recent mid-run checkpoint (checkpoint='tool-batch' runs)
+             */
+            last_checkpoint_at_message_index?: number | null;
         };
         /** TeamSessionDetailSchema */
         TeamSessionDetailSchema: {
@@ -4768,6 +6938,8 @@ export interface components {
              * @description Team execution mode (coordinate, route, broadcast, tasks)
              */
             mode?: string | null;
+            /** @description Model used by the team leader */
+            model?: components["schemas"]["Model"] | null;
         };
         /** TestConnectionResponse */
         TestConnectionResponse: {
@@ -4775,6 +6947,24 @@ export interface components {
             success: boolean;
             /** Message */
             message: string;
+        };
+        /**
+         * TextPart
+         * @description Represents a text segment within a message or artifact.
+         */
+        TextPart: {
+            /**
+             * Kind
+             * @default text
+             * @constant
+             */
+            kind: "text";
+            /** Metadata */
+            metadata?: {
+                [key: string]: unknown;
+            } | null;
+            /** Text */
+            text: string;
         };
         /**
          * TraceDetail
@@ -5181,21 +7371,81 @@ export interface components {
         /**
          * UnauthenticatedResponse
          * @example {
-         *       "detail": "Unauthenticated access",
-         *       "error_code": "UNAUTHENTICATED"
+         *       "detail": "Unauthenticated access"
          *     }
          */
         UnauthenticatedResponse: {
             /**
              * Detail
-             * @description Error detail message
+             * @description Human-readable error message
              */
             detail: string;
             /**
-             * Error Code
-             * @description Error code for categorization
+             * Error Id
+             * @description Stable identifier for the specific error, present only when the error carries one
              */
-            error_code?: string | null;
+            error_id?: string | null;
+            /**
+             * Error Type
+             * @description Category of the error, present only when the error carries one
+             */
+            error_type?: string | null;
+        };
+        /** UnavailableChunkerSchema */
+        UnavailableChunkerSchema: {
+            /**
+             * Id
+             * @description Chunker key that could not be loaded
+             */
+            id: string;
+            /**
+             * Name
+             * @description Name of the chunker
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description Description of the chunking strategy
+             */
+            description?: string | null;
+            /**
+             * Missing Packages
+             * @description Packages that are not importable
+             */
+            missing_packages?: string[];
+            /**
+             * Reason
+             * @description Verbatim import failure, including its install instruction
+             */
+            reason: string;
+        };
+        /** UnavailableReaderSchema */
+        UnavailableReaderSchema: {
+            /**
+             * Id
+             * @description Reader key that could not be loaded
+             */
+            id: string;
+            /**
+             * Name
+             * @description Name of the reader
+             */
+            name?: string | null;
+            /**
+             * Description
+             * @description Description of the reader's capabilities
+             */
+            description?: string | null;
+            /**
+             * Missing Packages
+             * @description Packages that are not importable
+             */
+            missing_packages?: string[];
+            /**
+             * Reason
+             * @description Verbatim import failure, including its install instruction
+             */
+            reason: string;
         };
         /** UpdateConnectionRequest */
         UpdateConnectionRequest: {
@@ -5209,6 +7459,8 @@ export interface components {
             user?: string | null;
             /** Password */
             password?: string | null;
+            /** Memory Namespace */
+            memory_namespace?: string | null;
         };
         /** UpdateEvalRunRequest */
         UpdateEvalRunRequest: {
@@ -5341,23 +7593,55 @@ export interface components {
             ctx?: Record<string, never>;
         };
         /**
+         * ValidationErrorDetail
+         * @description One field-level error inside a 422 body, matching FastAPI's default shape.
+         */
+        ValidationErrorDetail: {
+            /**
+             * Loc
+             * @description Path to the offending field, e.g. ['body', 'endpoint']
+             */
+            loc: (string | number)[];
+            /**
+             * Msg
+             * @description Human-readable error message
+             */
+            msg: string;
+            /**
+             * Type
+             * @description Error type identifier, e.g. 'value_error' or 'missing'
+             */
+            type: string;
+        };
+        /**
          * ValidationErrorResponse
+         * @description 422 body. Two runtime shapes share this status code, and the same endpoint can
+         *     return either, so ``detail`` is typed as their union:
+         *
+         *     - FastAPI's request-validation handler emits a **list** of field-level errors (built-in
+         *       coercion errors and custom-validator ``ValueError``s alike).
+         *     - A route that raises ``HTTPException(status_code=422, detail="...")`` for a semantic
+         *       check (e.g. an invalid cron expression) emits a **string** through the HTTPException
+         *       handler.
          * @example {
-         *       "detail": "Validation error",
-         *       "error_code": "VALIDATION_ERROR"
+         *       "detail": [
+         *         {
+         *           "loc": [
+         *             "body",
+         *             "endpoint"
+         *           ],
+         *           "msg": "Value error, Endpoint must be a path, not a full URL",
+         *           "type": "value_error"
+         *         }
+         *       ]
          *     }
          */
         ValidationErrorResponse: {
             /**
              * Detail
-             * @description Error detail message
+             * @description A single message for an explicitly raised 422, or a list of field-level errors for a request-validation failure
              */
-            detail: string;
-            /**
-             * Error Code
-             * @description Error code for categorization
-             */
-            error_code?: string | null;
+            detail: string | components["schemas"]["ValidationErrorDetail"][];
         };
         /** VectorDbSchema */
         VectorDbSchema: {
@@ -5436,7 +7720,7 @@ export interface components {
              * Id
              * @description Unique identifier for the search result document
              */
-            id: string;
+            id?: string | null;
             /**
              * Content
              * @description Content text of the document
@@ -5536,6 +7820,19 @@ export interface components {
              */
             workflow_agent: boolean;
             /**
+             * Is Factory
+             * @description Whether this workflow is a factory
+             * @default false
+             */
+            is_factory: boolean;
+            /**
+             * Factory Input Schema
+             * @description JSON Schema for factory_input
+             */
+            factory_input_schema?: {
+                [key: string]: unknown;
+            } | null;
+            /**
              * Is Component
              * @description Whether this workflow was created via Builder
              * @default false
@@ -5612,6 +7909,28 @@ export interface components {
             step_executor_runs?: {
                 [key: string]: unknown;
             }[] | null;
+            /**
+             * Step Requirements
+             * @description HITL step requirements (resolved state for historical display)
+             */
+            step_requirements?: {
+                [key: string]: unknown;
+            }[] | null;
+            /**
+             * Pause Kind
+             * @description Kind of HITL pause: 'step' or 'executor'
+             */
+            pause_kind?: string | null;
+            /**
+             * Paused Step Name
+             * @description Name of the step that caused the pause
+             */
+            paused_step_name?: string | null;
+            /**
+             * Paused Step Index
+             * @description Index of the step that caused the pause
+             */
+            paused_step_index?: number | null;
             /**
              * Metrics
              * @description Performance and usage metrics
@@ -5781,6 +8100,19 @@ export interface components {
              * @description Database identifier
              */
             db_id?: string | null;
+            /**
+             * Is Factory
+             * @description Whether this workflow is a factory
+             * @default false
+             */
+            is_factory: boolean;
+            /**
+             * Factory Input Schema
+             * @description JSON Schema for factory_input
+             */
+            factory_input_schema?: {
+                [key: string]: unknown;
+            } | null;
             /**
              * Is Component
              * @description Whether this workflow was created via Builder
@@ -6212,6 +8544,125 @@ export interface operations {
             };
         };
     };
+    apply_agent_agents_apply_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ApplyAgentRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApplyAgentResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_agent_agents__component_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Agent / component id */
+                component_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    list_toolsets_route_toolsets_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    }[];
+                };
+            };
+        };
+    };
+    get_toolset_route_toolsets__name__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Toolset name */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     health_check: {
         parameters: {
             query?: never;
@@ -6238,6 +8689,26 @@ export interface operations {
             };
         };
     };
+    get_info: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InfoResponse"];
+                };
+            };
+        };
+    };
     get_config: {
         parameters: {
             query?: never;
@@ -6257,7 +8728,16 @@ export interface operations {
                      * @example {
                      *       "id": "demo",
                      *       "description": "Example AgentOS configuration",
-                     *       "available_models": [],
+                     *       "available_models": [
+                     *         {
+                     *           "id": "gpt-4",
+                     *           "provider": "openai"
+                     *         },
+                     *         {
+                     *           "id": "claude-3-sonnet",
+                     *           "provider": "anthropic"
+                     *         }
+                     *       ],
                      *       "databases": [
                      *         "9c884dc4-9066-448c-9074-ef49ec7eb73c"
                      *       ],
@@ -6324,83 +8804,6 @@ export interface operations {
                      *     }
                      */
                     "application/json": components["schemas"]["ConfigResponse"];
-                };
-            };
-            /** @description Bad Request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["BadRequestResponse"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UnauthenticatedResponse"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NotFoundResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ValidationErrorResponse"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InternalServerErrorResponse"];
-                };
-            };
-        };
-    };
-    get_models: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of models retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    /**
-                     * @example [
-                     *       {
-                     *         "id": "gpt-4",
-                     *         "provider": "openai"
-                     *       },
-                     *       {
-                     *         "id": "claude-3-sonnet",
-                     *         "provider": "anthropic"
-                     *       }
-                     *     ]
-                     */
-                    "application/json": components["schemas"]["Model"][];
                 };
             };
             /** @description Bad Request */
@@ -6596,7 +8999,10 @@ export interface operations {
     };
     cancel_agent_run: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Session ID the run belongs to. Required for non-admin JWT users. */
+                session_id?: string | null;
+            };
             header?: never;
             path: {
                 agent_id: string;
@@ -6726,12 +9132,82 @@ export interface operations {
                     "application/json": components["schemas"]["NotFoundResponse"];
                 };
             };
-            /** @description Run is not paused (e.g. run is already running, continued, or errored). Only PAUSED runs can be continued. */
+            /** @description Continuation conflict: a durable queue ticket owns this run's continuation (continue it with background=true), or a continuation is already queued or executing. Runs in any state can be continued - a COMPLETED run forks into a follow-up; RUNNING/ERROR runs resume. */
             409: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    fork_agent_session: {
+        parameters: {
+            query?: {
+                user_id?: string | null;
+            };
+            header?: never;
+            path: {
+                agent_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Session forked successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Source session is empty or missing */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Agent not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
             };
             /** @description Validation Error */
             422: {
@@ -7002,6 +9478,222 @@ export interface operations {
             };
         };
     };
+    list_agent_run_checkpoints: {
+        parameters: {
+            query: {
+                /** @description Session ID for the run */
+                session_id: string;
+            };
+            header?: never;
+            path: {
+                agent_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Run checkpoints retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Agent or run not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    get_agent_run_checkpoint_snapshot: {
+        parameters: {
+            query: {
+                /** @description Session ID for the run */
+                session_id: string;
+            };
+            header?: never;
+            path: {
+                agent_id: string;
+                run_id: string;
+                message_index: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Run checkpoint snapshot retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Invalid checkpoint message index */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Agent or run not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    resume_agent_run_stream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["Body_resume_agent_run_stream"];
+            };
+        };
+        responses: {
+            /** @description SSE stream of catch-up and/or live events */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    "text/event-stream": unknown;
+                };
+            };
+            /** @description Not supported for remote agents */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Agent not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
     list_team_runs: {
         parameters: {
             query: {
@@ -7152,7 +9844,10 @@ export interface operations {
     };
     cancel_team_run: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Session ID the run belongs to. Required for non-admin JWT users. */
+                session_id?: string | null;
+            };
             header?: never;
             path: {
                 team_id: string;
@@ -7208,6 +9903,240 @@ export interface operations {
                 };
             };
             /** @description Failed to cancel team run */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    resume_team_run_stream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                team_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["Body_resume_team_run_stream"];
+            };
+        };
+        responses: {
+            /** @description SSE stream of catch-up and/or live events */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    "text/event-stream": unknown;
+                };
+            };
+            /** @description Not supported for remote teams */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Team not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    continue_team_run: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                team_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["Body_continue_team_run"];
+            };
+        };
+        responses: {
+            /** @description Team run continued successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    /**
+                     * @example event: RunContent
+                     *     data: {"created_at": 1757348314, "run_id": "123..."}
+                     */
+                    "text/event-stream": unknown;
+                };
+            };
+            /** @description Invalid JSON in requirements field or invalid requirement structure */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Run has a pending admin approval and cannot be continued by the user yet. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Team not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Continuation conflict: a durable queue ticket owns this run's continuation (continue it with background=true), or a continuation is already queued or executing. Runs in any state can be continued - a COMPLETED run forks into a follow-up; RUNNING/ERROR runs resume. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    fork_team_session: {
+        parameters: {
+            query?: {
+                user_id?: string | null;
+            };
+            header?: never;
+            path: {
+                team_id: string;
+                session_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Session forked successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Source session is empty or missing */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Team not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -7570,6 +10499,149 @@ export interface operations {
             };
         };
     };
+    list_team_run_checkpoints: {
+        parameters: {
+            query: {
+                /** @description Session ID for the run */
+                session_id: string;
+            };
+            header?: never;
+            path: {
+                team_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Run checkpoints retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Team or run not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    get_team_run_checkpoint_snapshot: {
+        parameters: {
+            query: {
+                /** @description Session ID for the run */
+                session_id: string;
+            };
+            header?: never;
+            path: {
+                team_id: string;
+                run_id: string;
+                message_index: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Run checkpoint snapshot retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Invalid checkpoint message index */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Team or run not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
     get_workflows: {
         parameters: {
             query?: never;
@@ -7647,7 +10719,10 @@ export interface operations {
     };
     get_workflow: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Workflow version to retrieve */
+                version?: number | null;
+            };
             header?: never;
             path: {
                 workflow_id: string;
@@ -7671,6 +10746,80 @@ export interface operations {
                      *     }
                      */
                     "application/json": components["schemas"]["WorkflowResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Workflow not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    list_workflow_runs: {
+        parameters: {
+            query: {
+                /** @description Session ID to list runs for */
+                session_id: string;
+                /** @description Filter by run status (PENDING, RUNNING, COMPLETED, ERROR, PAUSED) */
+                status?: string | null;
+                /** @description JSON object with factory-specific parameters for dynamic workflow reconstruction */
+                factory_input?: string | null;
+            };
+            header?: never;
+            path: {
+                workflow_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of runs retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
             /** @description Bad Request */
@@ -7796,9 +10945,96 @@ export interface operations {
             };
         };
     };
-    cancel_workflow_run: {
+    continue_workflow_run: {
         parameters: {
             query?: never;
+            header?: never;
+            path: {
+                workflow_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["Body_continue_workflow_run"];
+            };
+        };
+        responses: {
+            /** @description Workflow run continued successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    /**
+                     * @example event: StepCompleted
+                     *     data: {"step_name": "step1"}
+                     */
+                    "text/event-stream": unknown;
+                };
+            };
+            /** @description Invalid JSON in requirements field */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Workflow not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Run is not paused. Only PAUSED runs can be continued. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    cancel_workflow_run: {
+        parameters: {
+            query?: {
+                /** @description Session ID the run belongs to. Required for non-admin JWT users. */
+                session_id?: string | null;
+            };
             header?: never;
             path: {
                 workflow_id: string;
@@ -7864,11 +11100,86 @@ export interface operations {
             };
         };
     };
+    resume_workflow_run_stream: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workflow_id: string;
+                run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["Body_resume_workflow_run_stream"];
+            };
+        };
+        responses: {
+            /** @description SSE stream of catch-up and/or live events */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    "text/event-stream": unknown;
+                };
+            };
+            /** @description Not supported for remote workflows */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Workflow not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
     get_workflow_run: {
         parameters: {
             query: {
                 /** @description Session ID for the run */
                 session_id: string;
+                /** @description JSON object with factory-specific parameters for dynamic workflow reconstruction */
+                factory_input?: string | null;
             };
             header?: never;
             path: {
@@ -7935,11 +11246,697 @@ export interface operations {
             };
         };
     };
+    disabled_queue_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    disabled_queue_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    disabled_queue_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    disabled_queue_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    disabled_queue_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    get_agent_card_a2a_agents__id___well_known_agent_card_json_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_message_agent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Message sent successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "jsonrpc": "2.0",
+                     *       "id": "request-123",
+                     *       "result": {
+                     *         "task": {
+                     *           "id": "task-456",
+                     *           "context_id": "context-789",
+                     *           "status": "completed",
+                     *           "history": [
+                     *             {
+                     *               "message_id": "msg-1",
+                     *               "role": "agent",
+                     *               "parts": [
+                     *                 {
+                     *                   "kind": "text",
+                     *                   "text": "Response from agent"
+                     *                 }
+                     *               ]
+                     *             }
+                     *           ]
+                     *         }
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SendMessageSuccessResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Agent not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_agent_task: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_agent_task: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stream_message_agent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Streaming response with task updates */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    /**
+                     * @example event: TaskStatusUpdateEvent
+                     *     data: {"jsonrpc":"2.0","id":"request-123","result":{"taskId":"task-456","status":"working"}}
+                     *
+                     *     event: Message
+                     *     data: {"jsonrpc":"2.0","id":"request-123","result":{"messageId":"msg-1","role":"agent","parts":[{"kind":"text","text":"Response"}]}}
+                     */
+                    "text/event-stream": unknown;
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Agent not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_team_card_a2a_teams__id___well_known_agent_card_json_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_message_team: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Message sent successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "jsonrpc": "2.0",
+                     *       "id": "request-123",
+                     *       "result": {
+                     *         "task": {
+                     *           "id": "task-456",
+                     *           "context_id": "context-789",
+                     *           "status": "completed",
+                     *           "history": [
+                     *             {
+                     *               "message_id": "msg-1",
+                     *               "role": "agent",
+                     *               "parts": [
+                     *                 {
+                     *                   "kind": "text",
+                     *                   "text": "Response from agent"
+                     *                 }
+                     *               ]
+                     *             }
+                     *           ]
+                     *         }
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SendMessageSuccessResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Team not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_team_task: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    cancel_team_task: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stream_message_team: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Streaming response with task updates */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    /**
+                     * @example event: TaskStatusUpdateEvent
+                     *     data: {"jsonrpc":"2.0","id":"request-123","result":{"taskId":"task-456","status":"working"}}
+                     *
+                     *     event: Message
+                     *     data: {"jsonrpc":"2.0","id":"request-123","result":{"messageId":"msg-1","role":"agent","parts":[{"kind":"text","text":"Response"}]}}
+                     */
+                    "text/event-stream": unknown;
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Team not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_workflow_card_a2a_workflows__id___well_known_agent_card_json_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    run_message_workflow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Message sent successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "jsonrpc": "2.0",
+                     *       "id": "request-123",
+                     *       "result": {
+                     *         "task": {
+                     *           "id": "task-456",
+                     *           "context_id": "context-789",
+                     *           "status": "completed",
+                     *           "history": [
+                     *             {
+                     *               "message_id": "msg-1",
+                     *               "role": "agent",
+                     *               "parts": [
+                     *                 {
+                     *                   "kind": "text",
+                     *                   "text": "Response from agent"
+                     *                 }
+                     *               ]
+                     *             }
+                     *           ]
+                     *         }
+                     *       }
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SendMessageSuccessResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Workflow not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    stream_message_workflow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Streaming response with task updates */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    /**
+                     * @example event: TaskStatusUpdateEvent
+                     *     data: {"jsonrpc":"2.0","id":"request-123","result":{"taskId":"task-456","status":"working"}}
+                     *
+                     *     event: Message
+                     *     data: {"jsonrpc":"2.0","id":"request-123","result":{"messageId":"msg-1","role":"agent","parts":[{"kind":"text","text":"Response"}]}}
+                     */
+                    "text/event-stream": unknown;
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Workflow not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     get_sessions: {
         parameters: {
             query?: {
-                /** @description Type of sessions to retrieve (agent, team, or workflow) */
-                type?: components["schemas"]["SessionType"];
+                /** @description Type of sessions to retrieve (agent, team, or workflow). If not provided, returns all session types. */
+                type?: components["schemas"]["SessionType"] | null;
                 /** @description Filter sessions by component ID (agent/team/workflow ID) */
                 component_id?: string | null;
                 /** @description Filter sessions by user ID */
@@ -8093,6 +12090,13 @@ export interface operations {
                     "application/json": components["schemas"]["NotFoundResponse"];
                 };
             };
+            /** @description A session with the supplied session_id already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Validation error */
             422: {
                 headers: {
@@ -8122,6 +12126,8 @@ export interface operations {
                 db_id?: string | null;
                 /** @description Table to use for deletion */
                 table?: string | null;
+                /** @description Also delete the sessions' offloaded media from media storage */
+                delete_media?: boolean;
             };
             header?: never;
             path?: never;
@@ -8190,8 +12196,8 @@ export interface operations {
     get_session_by_id: {
         parameters: {
             query?: {
-                /** @description Session type (agent, team, or workflow) */
-                type?: components["schemas"]["SessionType"];
+                /** @description Session type (agent, team, or workflow). If not provided, auto-detected from session data. */
+                type?: components["schemas"]["SessionType"] | null;
                 /** @description User ID to query session from */
                 user_id?: string | null;
                 /** @description Database ID to query session from */
@@ -8273,6 +12279,8 @@ export interface operations {
                 db_id?: string | null;
                 /** @description Table to use for deletion */
                 table?: string | null;
+                /** @description Also delete the session's offloaded media from media storage */
+                delete_media?: boolean;
             };
             header?: never;
             path: {
@@ -8340,8 +12348,8 @@ export interface operations {
     update_session: {
         parameters: {
             query?: {
-                /** @description Session type (agent, team, or workflow) */
-                type?: components["schemas"]["SessionType"];
+                /** @description Session type (agent, team, or workflow). If not provided, auto-detected from session data. */
+                type?: components["schemas"]["SessionType"] | null;
                 /** @description User ID */
                 user_id?: string | null;
                 /** @description Database ID to use for update operation */
@@ -8421,8 +12429,8 @@ export interface operations {
     get_session_runs: {
         parameters: {
             query?: {
-                /** @description Session type (agent, team, or workflow) */
-                type?: components["schemas"]["SessionType"];
+                /** @description Session type (agent, team, or workflow). If not provided, auto-detected from session data. */
+                type?: components["schemas"]["SessionType"] | null;
                 /** @description User ID to query runs from */
                 user_id?: string | null;
                 /** @description Filter runs created after this Unix timestamp (epoch time in seconds) */
@@ -8502,8 +12510,8 @@ export interface operations {
     get_session_run: {
         parameters: {
             query?: {
-                /** @description Session type (agent, team, or workflow) */
-                type?: components["schemas"]["SessionType"];
+                /** @description Session type (agent, team, or workflow). If not provided, the run type is inferred from the run's own fields. */
+                type?: components["schemas"]["SessionType"] | null;
                 /** @description User ID to query run from */
                 user_id?: string | null;
                 /** @description Database ID to query run from */
@@ -8581,8 +12589,8 @@ export interface operations {
     rename_session: {
         parameters: {
             query?: {
-                /** @description Session type (agent, team, or workflow) */
-                type?: components["schemas"]["SessionType"];
+                /** @description Session type (agent, team, or workflow). If not provided, auto-detected from session data. */
+                type?: components["schemas"]["SessionType"] | null;
                 /** @description User ID to scope rename to */
                 user_id?: string | null;
                 /** @description Database ID to use for rename operation */
@@ -8656,6 +12664,91 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
+            };
+        };
+    };
+    get_session_media: {
+        parameters: {
+            query?: {
+                /** @description Session type (agent, team, or workflow). If not provided, auto-detected from session data. */
+                type?: components["schemas"]["SessionType"] | null;
+                /** @description User ID to query session from */
+                user_id?: string | null;
+                /** @description Database ID to query session from */
+                db_id?: string | null;
+                /** @description Table to query session from */
+                table?: string | null;
+                /** @description Redirect to a freshly-signed URL instead of streaming bytes */
+                redirect?: boolean;
+            };
+            header?: never;
+            path: {
+                /** @description Session ID the media belongs to */
+                session_id: string;
+                /** @description Storage key of the media to fetch */
+                storage_key: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The media bytes, served with the stored mime type */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                    "application/octet-stream": string;
+                };
+            };
+            /** @description Unauthenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Session or media not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+            /** @description Media storage could not be reached */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Remote databases are not supported */
+            501: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Media storage is not configured */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -9440,6 +13533,550 @@ export interface operations {
             };
         };
     };
+    list_learnings: {
+        parameters: {
+            query?: {
+                /** @description Filter by learning type */
+                learning_type?: string | null;
+                /** @description Filter by user ID */
+                user_id?: string | null;
+                /** @description Filter by agent ID */
+                agent_id?: string | null;
+                /** @description Filter by team ID */
+                team_id?: string | null;
+                /** @description Filter by session ID */
+                session_id?: string | null;
+                /** @description Filter by namespace */
+                namespace?: string | null;
+                /** @description Filter by entity ID */
+                entity_id?: string | null;
+                /** @description Filter by entity type */
+                entity_type?: string | null;
+                /** @description Page size */
+                limit?: number;
+                /** @description 1-indexed page number */
+                page?: number;
+                /** @description Field to sort by, e.g. `created_at` or `updated_at` (the default). An unrecognised field is ignored (the default ordering is used). */
+                sort_by?: string | null;
+                /** @description Sort order (asc or desc) */
+                sort_order?: components["schemas"]["SortOrder"] | null;
+                /** @description Database ID to query */
+                db_id?: string | null;
+                /** @description The database table to use (requires db_id) */
+                table?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_LearningResponse_"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    create_learning: {
+        parameters: {
+            query?: {
+                /** @description Database ID to use */
+                db_id?: string | null;
+                /** @description The database table to use (requires db_id) */
+                table?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LearningCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LearningResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    list_learning_users: {
+        parameters: {
+            query?: {
+                /** @description Restrict the grouping to a single learning type */
+                learning_type?: string | null;
+                /** @description Restrict the result to a single user */
+                user_id?: string | null;
+                /** @description Page size */
+                limit?: number;
+                /** @description 1-indexed page number */
+                page?: number;
+                /** @description Field to sort by: user_id or last_learning_updated_at (the default) */
+                sort_by?: string | null;
+                /** @description Sort order (asc or desc) */
+                sort_order?: components["schemas"]["SortOrder"] | null;
+                /** @description Database ID to query */
+                db_id?: string | null;
+                /** @description The database table to use (requires db_id) */
+                table?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_LearningUserStats_"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    delete_learning_user: {
+        parameters: {
+            query?: {
+                /** @description Restrict deletion to a single learning type; omit to delete all of the user's learnings */
+                learning_type?: string | null;
+                /** @description Database ID to use */
+                db_id?: string | null;
+                /** @description The database table to use (requires db_id) */
+                table?: string | null;
+            };
+            header?: never;
+            path: {
+                /** @description The user whose learnings should be deleted */
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    get_learning: {
+        parameters: {
+            query?: {
+                /** @description Database ID to query */
+                db_id?: string | null;
+                /** @description The database table to use (requires db_id) */
+                table?: string | null;
+            };
+            header?: never;
+            path: {
+                /** @description The learning ID */
+                learning_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LearningResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    delete_learning: {
+        parameters: {
+            query?: {
+                /** @description Database ID to use */
+                db_id?: string | null;
+                /** @description The database table to use (requires db_id) */
+                table?: string | null;
+            };
+            header?: never;
+            path: {
+                /** @description The learning ID */
+                learning_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    update_learning: {
+        parameters: {
+            query?: {
+                /** @description Database ID to use */
+                db_id?: string | null;
+                /** @description The database table to use (requires db_id) */
+                table?: string | null;
+            };
+            header?: never;
+            path: {
+                /** @description The learning ID */
+                learning_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LearningUpdate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LearningResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
     get_eval_runs: {
         parameters: {
             query?: {
@@ -9925,6 +14562,8 @@ export interface operations {
                 starting_date?: string | null;
                 /** @description Ending date for metrics range (YYYY-MM-DD format) */
                 ending_date?: string | null;
+                /** @description Return only this user's metrics. Ignored for non-admin callers */
+                user_id?: string | null;
                 /** @description Database ID to query metrics from */
                 db_id?: string | null;
                 /** @description The database table to use */
@@ -9946,7 +14585,7 @@ export interface operations {
                      * @example {
                      *       "metrics": [
                      *         {
-                     *           "id": "7bf39658-a00a-484c-8a28-67fd8a9ddb2a",
+                     *           "id": "2025-07-31_daily",
                      *           "agent_runs_count": 5,
                      *           "agent_sessions_count": 5,
                      *           "team_runs_count": 0,
@@ -10036,6 +14675,10 @@ export interface operations {
                 db_id?: string | null;
                 /** @description Table to use for metrics calculation */
                 table?: string | null;
+                /** @description Return only this user's metrics. Ignored for non-admin callers */
+                user_id?: string | null;
+                /** @description Run the refresh in the background and return 202 immediately */
+                background?: boolean;
             };
             header?: never;
             path?: never;
@@ -10052,7 +14695,7 @@ export interface operations {
                     /**
                      * @example [
                      *       {
-                     *         "id": "e77c9531-818b-47a5-99cd-59fed61e5403",
+                     *         "id": "2025-08-12_daily",
                      *         "agent_runs_count": 2,
                      *         "agent_sessions_count": 2,
                      *         "team_runs_count": 0,
@@ -10063,17 +14706,11 @@ export interface operations {
                      *         "token_metrics": {
                      *           "input_tokens": 256,
                      *           "output_tokens": 441,
-                     *           "total_tokens": 697,
-                     *           "audio_total_tokens": 0,
-                     *           "audio_input_tokens": 0,
-                     *           "audio_output_tokens": 0,
-                     *           "cache_read_tokens": 0,
-                     *           "cache_write_tokens": 0,
-                     *           "reasoning_tokens": 0
+                     *           "total_tokens": 697
                      *         },
                      *         "model_metrics": [
                      *           {
-                     *             "model_id": "gpt-4o",
+                     *             "model_id": "gpt-5.5",
                      *             "model_provider": "OpenAI",
                      *             "count": 2
                      *           }
@@ -10084,7 +14721,22 @@ export interface operations {
                      *       }
                      *     ]
                      */
-                    "application/json": components["schemas"]["DayAggregatedMetrics"][];
+                    "application/json": components["schemas"]["DayAggregatedMetrics"][] | components["schemas"]["MetricsRefreshResponse"];
+                };
+            };
+            /** @description Background refresh started */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "status": "started",
+                     *       "message": "Metrics refresh started in background"
+                     *     }
+                     */
+                    "application/json": unknown;
                 };
             };
             /** @description Bad Request */
@@ -10124,6 +14776,83 @@ export interface operations {
                 };
             };
             /** @description Failed to refresh metrics */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    get_metrics_refresh_status: {
+        parameters: {
+            query?: {
+                /** @description Database ID to get the refresh status for */
+                db_id?: string | null;
+                /** @description Table to get the refresh status for */
+                table?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current refresh status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "status": "completed",
+                     *       "started_at": "2025-08-12T08:01:47Z",
+                     *       "finished_at": "2025-08-12T08:01:49Z"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["MetricsRefreshStatusResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Database not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Failed to get refresh status */
             500: {
                 headers: {
                     [name: string]: unknown;
@@ -10235,6 +14964,13 @@ export interface operations {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
             };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     upload_content: {
@@ -10321,6 +15057,13 @@ export interface operations {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
             };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     delete_all_content: {
@@ -10390,6 +15133,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
+            };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -10475,6 +15225,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
+            };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -10563,6 +15320,13 @@ export interface operations {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
             };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     delete_content_by_id: {
@@ -10634,6 +15398,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
+            };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -10727,6 +15498,13 @@ export interface operations {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
             };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     get_content_status: {
@@ -10798,6 +15576,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
+            };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -10889,6 +15674,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
+            };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -10985,6 +15777,19 @@ export interface operations {
                      *             "AgenticChunker",
                      *             "DocumentChunker",
                      *             "RecursiveChunker"
+                     *           ]
+                     *         },
+                     *         "docling": {
+                     *           "id": "docling",
+                     *           "name": "DoclingReader",
+                     *           "description": "Converts multiple document formats like PDF, DOCX, PPTX, images, HTML, etc. using IBM's Docling library",
+                     *           "chunkers": [
+                     *             "AgenticChunker",
+                     *             "CodeChunker",
+                     *             "DocumentChunker",
+                     *             "FixedSizeChunker",
+                     *             "RecursiveChunker",
+                     *             "SemanticChunker"
                      *           ]
                      *         },
                      *         "docx": {
@@ -11086,10 +15891,12 @@ export interface operations {
                      *         ],
                      *         ".csv": [
                      *           "csv",
-                     *           "field_labeled_csv"
+                     *           "field_labeled_csv",
+                     *           "docling"
                      *         ],
                      *         ".xlsx": [
-                     *           "excel"
+                     *           "excel",
+                     *           "docling"
                      *         ],
                      *         ".xls": [
                      *           "excel"
@@ -11101,22 +15908,140 @@ export interface operations {
                      *           "excel"
                      *         ],
                      *         ".docx": [
-                     *           "docx"
+                     *           "docx",
+                     *           "docling"
                      *         ],
-                     *         ".doc": [
-                     *           "docx"
+                     *         ".dotx": [
+                     *           "docling"
+                     *         ],
+                     *         ".docm": [
+                     *           "docling"
+                     *         ],
+                     *         ".dotm": [
+                     *           "docling"
+                     *         ],
+                     *         ".pptx": [
+                     *           "docling",
+                     *           "pptx"
+                     *         ],
+                     *         ".potx": [
+                     *           "docling"
+                     *         ],
+                     *         ".ppsx": [
+                     *           "docling"
+                     *         ],
+                     *         ".pptm": [
+                     *           "docling"
+                     *         ],
+                     *         ".ppsm": [
+                     *           "docling"
+                     *         ],
+                     *         ".potm": [
+                     *           "docling"
                      *         ],
                      *         ".json": [
                      *           "json"
                      *         ],
                      *         ".md": [
-                     *           "markdown"
+                     *           "markdown",
+                     *           "docling"
                      *         ],
                      *         ".pdf": [
-                     *           "pdf"
+                     *           "pdf",
+                     *           "docling"
                      *         ],
                      *         ".txt": [
                      *           "text"
+                     *         ],
+                     *         ".html": [
+                     *           "docling"
+                     *         ],
+                     *         ".htm": [
+                     *           "docling"
+                     *         ],
+                     *         ".xhtml": [
+                     *           "docling"
+                     *         ],
+                     *         ".xml": [
+                     *           "docling"
+                     *         ],
+                     *         ".nxml": [
+                     *           "docling"
+                     *         ],
+                     *         ".xbrl": [
+                     *           "docling"
+                     *         ],
+                     *         ".adoc": [
+                     *           "docling"
+                     *         ],
+                     *         ".asciidoc": [
+                     *           "docling"
+                     *         ],
+                     *         ".asc": [
+                     *           "docling"
+                     *         ],
+                     *         ".xlsm": [
+                     *           "docling"
+                     *         ],
+                     *         ".tex": [
+                     *           "docling"
+                     *         ],
+                     *         ".latex": [
+                     *           "docling"
+                     *         ],
+                     *         ".tar.gz": [
+                     *           "docling"
+                     *         ],
+                     *         ".vtt": [
+                     *           "docling"
+                     *         ],
+                     *         ".png": [
+                     *           "docling"
+                     *         ],
+                     *         ".jpeg": [
+                     *           "docling"
+                     *         ],
+                     *         ".jpg": [
+                     *           "docling"
+                     *         ],
+                     *         ".tiff": [
+                     *           "docling"
+                     *         ],
+                     *         ".tif": [
+                     *           "docling"
+                     *         ],
+                     *         ".bmp": [
+                     *           "docling"
+                     *         ],
+                     *         ".webp": [
+                     *           "docling"
+                     *         ],
+                     *         ".wav": [
+                     *           "docling"
+                     *         ],
+                     *         ".mp3": [
+                     *           "docling"
+                     *         ],
+                     *         ".m4a": [
+                     *           "docling"
+                     *         ],
+                     *         ".aac": [
+                     *           "docling"
+                     *         ],
+                     *         ".ogg": [
+                     *           "docling"
+                     *         ],
+                     *         ".flac": [
+                     *           "docling"
+                     *         ],
+                     *         ".mp4": [
+                     *           "docling"
+                     *         ],
+                     *         ".avi": [
+                     *           "docling"
+                     *         ],
+                     *         ".mov": [
+                     *           "docling"
                      *         ]
                      *       },
                      *       "chunkers": {
@@ -11253,6 +16178,13 @@ export interface operations {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
             };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
     };
     list_content_sources: {
@@ -11333,6 +16265,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
+            };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -11443,6 +16382,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
                 };
+            };
+            /** @description No knowledge base is configured on this AgentOS */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -12033,6 +16979,8 @@ export interface operations {
                 page?: number;
                 /** @description Items per page */
                 limit?: number;
+                /** @description Also list archived (soft-deleted) components, marked by a deleted_at timestamp */
+                include_deleted?: boolean;
             };
             header?: never;
             path?: never;
@@ -12167,7 +17115,10 @@ export interface operations {
     };
     get_component: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Also return an archived (soft-deleted) component, marked by a deleted_at timestamp */
+                include_deleted?: boolean;
+            };
             header?: never;
             path: {
                 /** @description Component ID */
@@ -12235,7 +17186,10 @@ export interface operations {
     };
     delete_component: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Optional compare-and-set guard on the current version */
+                expected_current_version?: number | null;
+            };
             header?: never;
             path: {
                 /** @description Component ID */
@@ -12243,7 +17197,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ComponentDeleteRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             204: {
@@ -12314,6 +17272,74 @@ export interface operations {
                 "application/json": components["schemas"]["ComponentUpdate"];
             };
         };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ComponentResponse"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BadRequestResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthenticatedResponse"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ValidationErrorResponse"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    restore_component: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Component ID */
+                component_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
         responses: {
             /** @description Successful Response */
             200: {
@@ -12806,7 +17832,11 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["SetCurrentRequest"] | null;
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {
@@ -13383,6 +18413,103 @@ export interface operations {
             };
         };
     };
+    list_service_accounts_service_accounts_get: {
+        parameters: {
+            query?: {
+                include_revoked?: boolean;
+                limit?: number;
+                page?: number;
+                sort_by?: string;
+                sort_order?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_ServiceAccountResponse_"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    create_service_account_service_accounts_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ServiceAccountCreate"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ServiceAccountCreateResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    revoke_service_account_service_accounts__service_account_id__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                service_account_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     list_registry: {
         parameters: {
             query?: {
@@ -13453,6 +18580,96 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["InternalServerErrorResponse"];
+                };
+            };
+        };
+    };
+    get_models: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Model"][];
+                };
+            };
+        };
+    };
+    set_agent_model: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetAgentModelRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetModelResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    set_team_model: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                team_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetTeamModelRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetModelResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/src/resources/metrics.ts
+++ b/src/resources/metrics.ts
@@ -12,6 +12,8 @@ export interface GetMetricsOptions {
   startingDate?: string;
   /** End date in YYYY-MM-DD format */
   endingDate?: string;
+  /** Filter metrics to a single user */
+  userId?: string;
   /** Database ID */
   dbId?: string;
 }
@@ -67,6 +69,9 @@ export class MetricsResource {
     }
     if (options?.endingDate) {
       params.append("ending_date", options.endingDate);
+    }
+    if (options?.userId !== undefined) {
+      params.append("user_id", options.userId);
     }
     if (options?.dbId !== undefined) {
       params.append("db_id", options.dbId);

--- a/tests/resources/metrics.test.ts
+++ b/tests/resources/metrics.test.ts
@@ -81,6 +81,15 @@ describe("MetricsResource", () => {
       );
     });
 
+    it("adds user_id query param when userId provided", async () => {
+      const mockResponse = { metrics: [] };
+      requestSpy.mockResolvedValueOnce(mockResponse);
+
+      await resource.get({ userId: "u1" });
+
+      expect(requestSpy).toHaveBeenCalledWith("GET", "/metrics?user_id=u1");
+    });
+
     it("only includes defined params", async () => {
       const mockResponse = { metrics: [] };
       requestSpy.mockResolvedValueOnce(mockResponse);


### PR DESCRIPTION
Closes #1

Recaptures the AgentOS OpenAPI spec from an ixora stack running **agno 3.0.0** and regenerates `src/generated/types.ts` from it. The committed spec was captured before 2.8.5, so this is a large mechanical diff — what follows is the semantic delta, computed by diffing the old and new `openapi.json`.

## Scale

| | before | after |
|---|---|---|
| paths | 76 | 117 |
| schemas | 137 | 187 |

**No route was removed and no schema was removed.** Every `components["schemas"]` key that `src/resources/*.ts` reads still exists — `npm run typecheck` passes with only the one hand edit below.

## Routes added (50)

- **Info / discovery**: `GET /info`, `GET /toolsets`, `GET /toolsets/{name}`
- **Run control**: `POST /agents|teams|workflows/{id}/runs/{run_id}/resume`, `POST /teams/{team_id}/runs/{run_id}/continue`, `POST /workflows/{workflow_id}/runs/{run_id}/continue`, `GET /workflows/{workflow_id}/runs`
- **Checkpoints / forking**: `GET /agents|teams/{id}/runs/{run_id}/checkpoints`, `GET …/checkpoints/{message_index}`, `POST /agents|teams/{id}/sessions/{session_id}/fork`
- **Model switching**: `PATCH /agents/{agent_id}/model`, `PATCH /teams/{team_id}/model`
- **Components**: `POST /agents:apply`, `DELETE /agents/{component_id}`, `POST /components/{component_id}/restore`
- **Learnings** (7): `POST|GET /learnings`, `GET|DELETE|PATCH /learnings/{learning_id}`, `GET /learnings/users`, `DELETE /learnings/users/{user_id}`
- **Service accounts**: `GET|POST /service-accounts`, `DELETE /service-accounts/{service_account_id}`
- **Metrics / media**: `GET /metrics/refresh/status`, `GET /sessions/{session_id}/media/{storage_key}`
- **A2A interface** (13): `/a2a/{agents,teams,workflows}/{id}/…` agent cards, `message:send`, `message:stream`, `tasks:get`, `tasks:cancel`
- **Queue**: `GET|POST|PUT|PATCH|DELETE /queue` — see the note below

## Routes removed

None. In particular **`GET /models` survives**: agno 3.0 dropped it, but ixora re-adds its own with `operation_id: get_models`, and this capture is from an ixora stack (as #1 requires — a vanilla AgentOS spec would be wrong here, it has no `/auth/*` either). #2 adds the `/config` fallback for vanilla servers.

## Schema shapes that changed

**Error payloads** — `error_code` is gone everywhere:
- `BadRequestResponse`, `NotFoundResponse`, `UnauthenticatedResponse`, `InternalServerErrorResponse`: `-error_code`, `+error_id`, `+error_type`
- `ValidationErrorResponse`: `-error_code`, and `detail` widened from `string` to `string | ValidationErrorDetail[]`

**Config**:
- `ConfigResponse.available_models`: `string[] | null` → `Model[]` (`{ id, provider }`) — this is what #2 builds on
- `ConfigResponse`: `+learning`, `+manifest`
- `EvalsConfig` / `EvalsDomainConfig`: `-available_models`

**Ownership / provenance** (the `user_id` stamping):
- `EvalSchema`, `ScheduleRunResponse`, `ComponentResponse`: `+user_id` (plus `ComponentResponse.deleted_at`)
- `ScheduleResponse`: `+user_id`, `+managed_by`, `+target_type`, `+target_id`, `+disabled_reason`

**Runs / sessions**:
- `RunSchema`, `TeamRunSchema`: `+forked_from_run_id`, `+forked_from_session_id`, `+forked_from_message_index`, `+last_checkpoint_at_message_index`, `+regenerated_from`
- `WorkflowRunSchema`: `+pause_kind`, `+paused_step_index`, `+paused_step_name`, `+step_requirements`
- `SessionSchema`: `+agent_id`, `+team_id`, `+workflow_id`, `+user_id`, `+metadata`, `+metrics`, `+session_summary`, `+session_type`, `+total_tokens`
- `Body_continue_agent_run`: `+background`, `+continue_from`, `+fork`, `+input`, `+regenerate`, `+replace_original`, `+additional_instructions`
- `Body_create_agent_run` / `Body_create_team_run`: `+factory_input`, `+files_metadata`; `Body_create_workflow_run`: `+background`, `+factory_input`
- ⚠️ `Body_create_agent_run.version`: `string` → `integer`

**Components / factories**: `AgentResponse`, `TeamResponse`, `WorkflowResponse`, `WorkflowSummaryResponse` gain `is_factory` / `factory_input_schema`; `AgentSummaryResponse`/`TeamSummaryResponse` gain `model`; `ComponentUpdate`/`ConfigCreate`/`ConfigUpdate` gain `guard`.

**Connections**: `ConnectionResponse`, `AdminConnectionResponse`, `CreateConnectionRequest`, `UpdateConnectionRequest` gain `memory_namespace`.

**Misc**: `EvalRunInput` gains `allow_additional_tool_calls` / `expected_tool_call_arguments` (these existed in 2.8.5 — their absence was spec staleness, not a 3.0 addition); `ReaderSchema` gains `content_types` / `unavailable_content_types`; `VectorSearchResult.id` became nullable; `Body_*` file fields moved from `format: binary` to `contentMediaType: application/octet-stream` (a FastAPI/pydantic emission change, no runtime effect — file upload tests still pass).

## Hand edits (2)

1. **`src/resources/metrics.ts`** — `GetMetricsOptions.userId`, appended as `user_id` on `GET /metrics`. 3.0 added that query param and the generator cannot infer the option object. Covered by a new case in `tests/resources/metrics.test.ts`. Needed by ibmi-agi/ixora-cli#114.
2. **`openapi.json`** — renamed the `operation_id` of `GET /components/{component_id}/configs/{version}` from `get_config` to `get_config_version`.

   This one is not in the issue. **agno 3.0.0 has an upstream `operation_id` collision**: `libs/agno/agno/os/router.py:98` and `libs/agno/agno/os/routers/components/components.py:1336` both declare `operation_id="get_config"`. `openapi-typescript` keys its `operations` map by `operationId`, so a raw capture emits a duplicate `get_config` and `npm run typecheck` fails with `TS2300: Duplicate identifier 'get_config'`. The rename matches the handler's own name (`async def get_config_version`), so it is almost certainly an upstream copy-paste bug. The normalization is documented in README so the next capture reapplies it.

## Note on `/queue`

#1 predicted `/queue/jobs`, `/queue/jobs/{job_id}`, `/queue/jobs/{job_id}/requeue` and `/queue/stats`. **Those are not in this capture and cannot be.** agno only mounts the real job-queue router when the OS is configured with `queue=QueueConfig(durable=True)`; otherwise `app.py:709` mounts `_get_disabled_feature_router("/queue", "Queue", …)`, which is what this ixora stack has. The spec therefore carries a single `/queue` path with five methods, all `operationId: disabled_queue_*`, summary `Disabled`.

So the `/queue/jobs` line of #1's *Done when* is not satisfiable from an ixora stack that does not enable the durable queue — the surface will appear in the types only once a capture comes from an OS with the queue turned on. Everything else in *Done when* holds:

- ✅ `BadRequestResponse` has `error_id`/`error_type`, no `error_code` (`grep -c error_code src/generated/types.ts` → 0)
- ✅ `ScheduleResponse` has `user_id`/`managed_by`/`target_type`/`target_id`/`disabled_reason`
- ✅ `EvalSchema` and `ScheduleRunResponse` have `user_id`
- ✅ `client.metrics.get({ userId: "u1" })` requests `/metrics?user_id=u1`
- ✅ only `src/resources/metrics.ts` changed under `src/resources/`

## Verification

Spec captured from a live agno 3.0.0 ixora stack at `http://localhost:8031/openapi.json` (`GET /health` → `{"status":"ok"}`); regenerated with the repo's own `npm run generate:types`. `npm run lint`, `npm run typecheck`, `npm test` (825 tests, 26 files) and `npm run validate` (build + publint + attw) all pass locally.

No version bump and no npm publish here — releasing is handled separately. Downstream consumers (ibmi-agi/ixora-cli#109, ixora-sdk#1) wait on that publish.

---
Part of the agno 3.0 migration (ibmi-agi/ixora#223). **#13 is stacked on this branch** and is the PR that resolves issue 2 — it types `getConfig()` as `ConfigResponse`, which only works once this regen lands. Merge this one first.

