### PR TITLE
feat(models): fall back to /config available_models when /models 404s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ This project follows [Semantic Versioning](https://semver.org/).
     `target_id` and `disabled_reason`.
   - `Body_create_agent_run.version` changed from `string` to `integer`.
 
+- `client.models.list()` now falls back to `GET /config` -> `available_models`
+  when `GET /models` answers 404. agno 3.0 removed the `/models` route, so
+  `models.list()` threw `NotFoundError` against a vanilla agno >= 3.0 server;
+  `/models` is still the first attempt, and ixora stacks (which keep their own
+  `/models` serving a superset catalog) are unaffected.
+- `AgentOSClient.getConfig()` returns `components["schemas"]["ConfigResponse"]`
+  instead of the hand-written `OSConfig`, so `available_models` typechecks as
+  `Model[]`.
+
 ### Breaking
 
 Consumers that type-reference the re-exported `components`/`paths` are affected
@@ -55,6 +64,9 @@ warnings:
 - Enums grew, which breaks exhaustive `switch`/never-checks: `RunStatus` gained
   `REGENERATED`; `RegistryResourceType` gained `workflow`, `knowledge`,
   `memory_manager`, `session_summary_manager` and `learning`.
+- The hand-written `OSConfig` type is no longer exported. It never matched the
+  server's `/config` payload; use `components["schemas"]["ConfigResponse"]`
+  instead. `AgentOSClient.getConfig()` returns that type now.
 
 Release note: this warrants a minor bump (0.7.0), not a patch.
 

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ new AgentOSClient(options: AgentOSClientOptions)
 - `maxRetries?: number` - Maximum retry attempts (default: 3)
 
 **Methods:**
-- `getConfig(): Promise<OSConfig>` - Get server configuration
+- `getConfig(): Promise<ConfigResponse>` - Get server configuration (`components['schemas']['ConfigResponse']`)
 - `health(): Promise<HealthStatus>` - Check API health status
 
 ### Resource Namespaces

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import { createErrorFromResponse } from "./errors";
+import type { components } from "./generated/types";
 import { requestWithRetry } from "./http";
 import { VERSION } from "./index";
 import { AgentsResource } from "./resources/agents";
@@ -20,9 +21,10 @@ import { WorkflowsResource } from "./resources/workflows";
 import type {
   AgentOSClientOptions,
   HealthStatus,
-  OSConfig,
   RequestOptions,
 } from "./types";
+
+type ConfigResponse = components["schemas"]["ConfigResponse"];
 
 /**
  * AgentOS API client
@@ -101,8 +103,8 @@ export class AgentOSClient {
   /**
    * Get OS configuration
    */
-  async getConfig(): Promise<OSConfig> {
-    return this.request<OSConfig>("GET", "/config");
+  async getConfig(): Promise<ConfigResponse> {
+    return this.request<ConfigResponse>("GET", "/config");
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ export { AgentOSClient } from "./client";
 export type {
   AgentOSClientOptions,
   HealthStatus,
-  OSConfig,
   RequestOptions,
 } from "./types";
 

--- a/src/resources/models.ts
+++ b/src/resources/models.ts
@@ -1,4 +1,5 @@
 import type { AgentOSClient } from "../client";
+import { NotFoundError } from "../errors";
 import type { components } from "../generated/types";
 
 // Extract types from generated schemas
@@ -24,6 +25,12 @@ export class ModelsResource {
   /**
    * List all available models
    *
+   * Calls `GET /models` first. agno removed that route in 3.0, so a vanilla
+   * agno >= 3.0 server answers 404 and this falls back to `available_models`
+   * on `GET /config` — the models actually in use by the registered agents and
+   * teams. ixora keeps its own `/models` route and serves the full catalog, so
+   * the fallback never runs against an ixora stack.
+   *
    * @returns Array of model configurations
    *
    * @example
@@ -33,6 +40,13 @@ export class ModelsResource {
    * ```
    */
   async list(): Promise<Model[]> {
-    return this.client.request<Model[]>("GET", "/models");
+    try {
+      return await this.client.request<Model[]>("GET", "/models");
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        return (await this.client.getConfig()).available_models ?? [];
+      }
+      throw error;
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,15 +43,6 @@ export interface RequestOptions {
 }
 
 /**
- * OS configuration response from /config endpoint
- */
-export interface OSConfig {
-  version: string;
-  environment: string;
-  features: Record<string, boolean>;
-}
-
-/**
  * Health status response from /health endpoint
  */
 export interface HealthStatus {

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -74,9 +74,13 @@ describe("AgentOSClient", () => {
   describe("getConfig", () => {
     it("should fetch config from /config endpoint", async () => {
       const mockConfig = {
-        version: "1.0.0",
-        environment: "production",
-        features: { streaming: true },
+        os_id: "test-os",
+        available_models: [{ id: "gpt-4", provider: "OpenAI" }],
+        databases: [],
+        agents: [],
+        teams: [],
+        workflows: [],
+        interfaces: [],
       };
       mockRequestWithRetry.mockResolvedValueOnce(mockConfig);
 
@@ -96,7 +100,7 @@ describe("AgentOSClient", () => {
     });
 
     it("should include default headers in getConfig request", async () => {
-      mockRequestWithRetry.mockResolvedValueOnce({ version: "1.0.0" });
+      mockRequestWithRetry.mockResolvedValueOnce({ os_id: "test-os" });
 
       const client = new AgentOSClient({
         baseUrl: "https://api.example.com",

--- a/tests/resources/models.test.ts
+++ b/tests/resources/models.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentOSClient } from "../../src/client";
+import { NotFoundError } from "../../src/errors";
 import { ModelsResource } from "../../src/resources/models";
 
 describe("ModelsResource", () => {
@@ -48,6 +49,40 @@ describe("ModelsResource", () => {
       requestSpy.mockRejectedValueOnce(new Error("Unauthorized"));
 
       await expect(resource.list()).rejects.toThrow("Unauthorized");
+    });
+
+    it("falls back to /config available_models on 404", async () => {
+      const availableModels = [
+        { id: "gpt-4", provider: "OpenAI" },
+        { id: "claude-3", provider: "Anthropic" },
+      ];
+      requestSpy.mockRejectedValueOnce(new NotFoundError("Not Found"));
+      const getConfigSpy = vi
+        .spyOn(mockClient, "getConfig")
+        // biome-ignore lint/suspicious/noExplicitAny: partial ConfigResponse fixture
+        .mockResolvedValueOnce({ available_models: availableModels } as any);
+
+      const result = await resource.list();
+
+      expect(result).toEqual(availableModels);
+      expect(requestSpy).toHaveBeenCalledWith("GET", "/models");
+      expect(getConfigSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns an empty array when /config omits available_models", async () => {
+      requestSpy.mockRejectedValueOnce(new NotFoundError("Not Found"));
+      // biome-ignore lint/suspicious/noExplicitAny: partial ConfigResponse fixture
+      vi.spyOn(mockClient, "getConfig").mockResolvedValueOnce({} as any);
+
+      await expect(resource.list()).resolves.toEqual([]);
+    });
+
+    it("does not fall back on non-404 errors", async () => {
+      requestSpy.mockRejectedValueOnce(new Error("boom"));
+      const getConfigSpy = vi.spyOn(mockClient, "getConfig");
+
+      await expect(resource.list()).rejects.toThrow("boom");
+      expect(getConfigSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes #2

> #12 has merged (`dcf1614`) and this branch was rebased onto `main`, so it is no longer stacked — the whole diff is this PR's own work, in one commit. The `ConfigResponse` typing depends on #12's regenerated spec, which is now in `main`.

## Problem

agno 3.0 removed `GET /models` — the only route dropped between 2.8.5 and 3.0 — and moved the list into `GET /config` as `available_models`, changing its entries from plain strings to `{ id, provider }` objects. `ModelsResource.list()` calls `/models` directly, so against a vanilla agno >= 3.0 server it throws a 404-derived `NotFoundError`.

ixora stacks were never affected: ixora installs its own `/models` route (`app/models_router.py:173-186`) serving a superset catalog — team members plus `IXORA_MODELS`, not just the models in use.

## Change

**`src/resources/models.ts`** — `/models` stays the first attempt; only a `NotFoundError` triggers the fallback:

```ts
async list(): Promise<Model[]> {
  try {
    return await this.client.request<Model[]>("GET", "/models");
  } catch (error) {
    if (error instanceof NotFoundError) {
      return (await this.client.getConfig()).available_models ?? [];
    }
    throw error;
  }
}
```

Any other error still propagates. JSDoc on `list()` spells out the vanilla-vs-ixora split.

**`src/client.ts`** — `getConfig()` now returns `components["schemas"]["ConfigResponse"]`, so `.available_models` typechecks as `Model[]` without a cast.

**`src/types.ts` / `src/index.ts`** — deleted the hand-written `OSConfig` (`{ version, environment, features }`). It never matched the server's `/config` payload; nothing in the SDK read it beyond `getConfig()`'s signature.

## Breaking

`OSConfig` is no longer exported. Consumers that named the type explicitly should use `components["schemas"]["ConfigResponse"]` (`components` is already re-exported from the package root). ixora-cli only reaches `getConfig()` through `unknown` casts (`knowledge.ts:446`, `status.ts:71`), which keep working — and those casts can now be dropped.

## Verification

Beyond `npm test` (828 tests, 26 files, +3 new cases in `tests/resources/models.test.ts`: 404 fallback, empty-`available_models` → `[]`, non-404 propagation), the built client was run against a **live agno 3.0.0 ixora stack**:

```
models.list()             -> [{"id":"claude-sonnet-4-6","provider":"Anthropic"}]   # ixora /models, unchanged
config.available_models   -> [{"id":"claude-sonnet-4-6","provider":"Anthropic"}]   # typed Model[], .id/.provider read directly
vanilla fallback          -> [{"id":"claude-sonnet-4-6","provider":"Anthropic"}]   # /models forced to 404 -> /config path
```

`npm run lint`, `npm run typecheck` and `npm run validate` (build + publint + attw) also pass.

## Not in this PR

No version bump and no npm publish — releasing is handled separately. Once published, ibmi-agi/ixora-cli#109 and ixora-sdk#1 inherit this fallback on a dependency bump (ixora-sdk re-exports the SDK wholesale), so neither needs a hand-rolled fallback of its own.

---
Part of the agno 3.0 migration (ibmi-agi/ixora#223).

