### PR TITLE
[throwaway] CI baseline probe — do not merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,3 +132,5 @@ Initial release of the AgentOS TypeScript SDK.
 [0.1.2]: https://github.com/ajshedivy/agentos-sdk/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ajshedivy/agentos-sdk/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ajshedivy/agentos-sdk/releases/tag/v0.1.0
+
+<!-- ci baseline probe -->


### PR DESCRIPTION
Throwaway PR: runs CI on the pristine `main` tree (v0.6.2 + a comment line in CHANGELOG) to establish today's baseline for the test job, so the failures on #12/#13 can be attributed. Will be closed as soon as CI reports.