### PR TITLE
fix(ci): green the Node 18 test job and stop fail-fast masking Node 20/22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
+      # One version's failure must not cancel the others - a red Node 18 was
+      # hiding whether Node 20 and 22 passed at all.
+      fail-fast: false
       matrix:
         node-version: [18, 20, 22]
     steps:

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -1,7 +1,25 @@
+import * as nodeBuffer from "node:buffer";
 import * as fs from "node:fs";
 import type { ReadStream } from "node:fs";
 import * as path from "node:path";
 import type { FileInput } from "../types/files";
+
+/**
+ * Resolve the File constructor. Node 18 has no global `File` (it became global
+ * in Node 20) but exposes the same class on `node:buffer`, so fall back to it:
+ * a plain Blob carries no name and the multipart part would be sent as
+ * `filename="blob"`, losing the extension the server uses to detect the type.
+ *
+ * Resolved lazily so Node 18 only emits its `buffer.File` experimental warning
+ * when a file is actually normalized.
+ */
+function getFileCtor(): typeof File | undefined {
+  if (typeof File !== "undefined") {
+    return File;
+  }
+  // Typed as always present, but absent before Node 18.13 - hence `| undefined`.
+  return nodeBuffer.File;
+}
 
 /**
  * Read a file from disk into a File (or Blob when the File constructor is
@@ -11,9 +29,10 @@ import type { FileInput } from "../types/files";
 function readPathToFile(p: fs.PathLike, filename?: string): Blob | File {
   const data = fs.readFileSync(p);
   const name = filename ?? path.basename(String(p));
-  if (typeof File !== "undefined") {
+  const FileCtor = getFileCtor();
+  if (FileCtor) {
     // biome-ignore lint/suspicious/noExplicitAny: Buffer ArrayBufferLike incompatibility workaround
-    return new File([data as any], name);
+    return new FileCtor([data as any], name);
   }
   // biome-ignore lint/suspicious/noExplicitAny: Buffer ArrayBufferLike incompatibility workaround
   return new Blob([data as any]);
@@ -76,9 +95,12 @@ export function normalizeFileInput(
   if (Buffer.isBuffer(input)) {
     // Create Blob with optional filename via File constructor if available
     // Note: Buffer extends Uint8Array, safe to use in Blob/File constructors
-    if (filename && typeof File !== "undefined") {
-      // biome-ignore lint/suspicious/noExplicitAny: Buffer ArrayBufferLike incompatibility workaround
-      return new File([input as any], filename);
+    if (filename) {
+      const FileCtor = getFileCtor();
+      if (FileCtor) {
+        // biome-ignore lint/suspicious/noExplicitAny: Buffer ArrayBufferLike incompatibility workaround
+        return new FileCtor([input as any], filename);
+      }
     }
     // biome-ignore lint/suspicious/noExplicitAny: Buffer ArrayBufferLike incompatibility workaround
     return new Blob([input as any]);

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -10,14 +10,17 @@ import type { FileInput } from "../types/files";
  * a plain Blob carries no name and the multipart part would be sent as
  * `filename="blob"`, losing the extension the server uses to detect the type.
  *
- * Resolved lazily so Node 18 only emits its `buffer.File` experimental warning
- * when a file is actually normalized.
+ * Node 18 prints `ExperimentalWarning: buffer.File` the first time one of these
+ * is constructed, so only consumers that actually upload a file ever see it.
  */
 function getFileCtor(): typeof File | undefined {
   if (typeof File !== "undefined") {
     return File;
   }
-  // Typed as always present, but absent before Node 18.13 - hence `| undefined`.
+  // Namespace import, not `import { File }`: `node:buffer` only exports File
+  // from Node 18.13 on, and a named import of a missing export fails at link
+  // time. Typed as always present, but undefined before 18.13 - hence the
+  // `| undefined`, which falls back to an unnamed Blob as it did before.
   return nodeBuffer.File;
 }
 

--- a/tests/utils/files.test.ts
+++ b/tests/utils/files.test.ts
@@ -63,6 +63,19 @@ describe("normalizeFileInput", () => {
       expect(result).toBeInstanceOf(Blob);
     });
 
+    it("serializes a named Buffer into a multipart file part", async () => {
+      // Regression: on Node 18 there is no global File, so the filename used to
+      // be dropped and the part was sent as filename="blob".
+      const formData = new FormData();
+      formData.append("file", normalizeFileInput(Buffer.from("x"), "n.txt"));
+
+      const body = await new Request("http://test/", {
+        method: "POST",
+        body: formData,
+      }).text();
+      expect(body).toContain('filename="n.txt"');
+    });
+
     it("converts Buffer to File when filename provided and File exists", () => {
       const buffer = Buffer.from("test content");
 


### PR DESCRIPTION
## Problem

CI has been red on `main` for a while, and the failure was hiding a second one.

**1. `Test (Node 18)` fails on a real bug.** `tests/utils/files.test.ts` asserts that a file path normalized for upload serializes as a multipart part named `filename="test-file.txt"`. On Node 18 it comes out as `filename="blob"`.

Root cause: Node 18 has no global `File` (it became global in Node 20). `readPathToFile` in `src/utils/files.ts` therefore fell through to its `new Blob(...)` branch, and a Blob carries no name — undici names an unnamed part `blob`. That drops the extension the server uses to detect content type, so uploads from any Node 18 consumer are typed wrong. `package.json` declares `"engines": { "node": ">=18.0.0" }`, so this is a supported target and the code is what's wrong, not the test.

The `Buffer` branch had the identical defect: `normalizeFileInput(buf, "image.png")` on Node 18 silently discarded the explicit `filename`.

**2. `fail-fast` was masking Node 20 and 22.** Both were `CANCELLED`, not failed — the matrix default killed them the moment Node 18 went red, so nobody knew whether they passed.

## Fix

- `src/utils/files.ts`: fall back to the `File` class exposed on `node:buffer` when the global is absent (Node 18.13+ has it; it is the same undici class, so `FormData` accepts it as file-like). Node 18 prints an `ExperimentalWarning: buffer.File` on the first such construction, so only consumers that actually upload a file see it; it is left alone rather than suppressed. Node 18.0-18.12 has no `buffer.File` either and keeps the old unnamed-`Blob` behaviour - the import is a namespace import precisely so those versions do not fail at link time. Applied to both the path and Buffer branches.
- `.github/workflows/ci.yml`: `fail-fast: false` on the test matrix.
- `tests/utils/files.test.ts`: one added regression test covering the Buffer + explicit filename path, which no cross-version assertion covered before. No existing assertion was weakened.

## Verification

Reproduced and fixed locally on real Node 18 (v18.20.8 via nvm), not just in CI.

Before, on Node 18:
```
FAIL  tests/utils/files.test.ts > normalizeFileInput > string path input (Node.js) > serializes into a multipart file part, not a string field
AssertionError: expected '------formdata-undici-027514950830\r\...' to contain 'filename="test-file.txt"'
+ Content-Disposition: form-data; name="file"; filename="blob"
Test Files  1 failed | 25 passed (26)
     Tests  1 failed | 823 passed (824)
```

After — `npm run test:coverage`, `825 passed (825)` on **v18.20.8, v20.20.2, v22.23.2 and v24.15.0**. `npm run lint`, `npm run typecheck` and `npm run validate` all pass on v22. The built `dist/` was also smoke-tested on Node 18 and 22 in both ESM and CJS: the multipart part is named `test-file.txt` in all four combinations.

Independent of the agno 3.0 migration work — this failure predates it and reproduces on a pristine `main`. Based on `main`, not part of stack #15.
