### PR TITLE
feat(api): add client.info(), components.restore()/includeDeleted, metrics refresh body + refreshStatus()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ Consumers that type-reference the re-exported `components`/`paths` are affected
 by the regeneration. Under `strict` TypeScript these are compile errors, not
 warnings:
 
+- `HealthStatus` (the return type of `client.health()`) is now an alias of
+  `components["schemas"]["HealthResponse"]`: `{ status: string;
+  instantiated_at: string }`. The previous hand-written shape
+  (`status: "healthy" | "degraded" | "unhealthy"`, `timestamp`, `details`)
+  never matched what `GET /health` returns. Code that read `.timestamp` or
+  `.details`, or narrowed `.status` against those literals, no longer compiles;
+  code that cast the result through `unknown` to reach `instantiated_at` can
+  drop the cast.
 - `error_code` is gone from every error schema; read `error_id` / `error_type`
   instead (`ValidationErrorResponse` carries neither).
 - `ConfigResponse.available_models` is `Model[]` (`{ id, provider }`), not
@@ -76,14 +84,6 @@ warnings:
 - The hand-written `OSConfig` type is no longer exported. It never matched the
   server's `/config` payload; use `components["schemas"]["ConfigResponse"]`
   instead. `AgentOSClient.getConfig()` returns that type now.
-- `HealthStatus` (the return type of `client.health()`) is now an alias of
-  `components["schemas"]["HealthResponse"]`: `{ status: string;
-  instantiated_at: string }`. The previous hand-written shape
-  (`status: "healthy" | "degraded" | "unhealthy"`, `timestamp`, `details`)
-  never matched what `GET /health` returns. Code that read `.timestamp` or
-  `.details`, or narrowed `.status` against those literals, no longer compiles;
-  code that cast the result through `unknown` to reach `instantiated_at` can
-  drop the cast.
 
 Release note: this warrants a minor bump (0.7.0), not a patch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ This project follows [Semantic Versioning](https://semver.org/).
 - `AgentOSClient.getConfig()` returns `components["schemas"]["ConfigResponse"]`
   instead of the hand-written `OSConfig`, so `available_models` typechecks as
   `Model[]`.
+- `metrics.refresh()` now returns the response body instead of discarding it:
+  `DayAggregatedMetrics[]` on the default synchronous path (the server has
+  returned this list since 2.8.5), or `MetricsRefreshResponse`
+  (`{ status, message }`) when the server reports `already_running` or when
+  `background: true` is passed. Discriminate with `Array.isArray()`. Callers
+  that ignored the old `void` result are unaffected.
+- `components.delete()` is documented as an archive (soft delete): the server
+  stamps `deleted_at` and keeps the id reserved. It has behaved this way since
+  2.8.5; the JSDoc said "delete".
 
 ### Breaking
 
@@ -67,12 +76,39 @@ warnings:
 - The hand-written `OSConfig` type is no longer exported. It never matched the
   server's `/config` payload; use `components["schemas"]["ConfigResponse"]`
   instead. `AgentOSClient.getConfig()` returns that type now.
+- `HealthStatus` (the return type of `client.health()`) is now an alias of
+  `components["schemas"]["HealthResponse"]`: `{ status: string;
+  instantiated_at: string }`. The previous hand-written shape
+  (`status: "healthy" | "degraded" | "unhealthy"`, `timestamp`, `details`)
+  never matched what `GET /health` returns. Code that read `.timestamp` or
+  `.details`, or narrowed `.status` against those literals, no longer compiles;
+  code that cast the result through `unknown` to reach `instantiated_at` can
+  drop the cast.
 
 Release note: this warrants a minor bump (0.7.0), not a patch.
 
 ### Added
 
 - `GetMetricsOptions.userId`, sent as the `user_id` query param on `GET /metrics`.
+- `client.info()` -> `GET /info`, typed as `components["schemas"]["InfoResponse"]`
+  (`os_id`, `name`, `os_version`, `agno_version`, `agent_count`, `team_count`,
+  `workflow_count`, `mcp`, `auth_mode`). The only route that reports the running
+  AgentOS version now that `GET /` left the OpenAPI schema.
+- `components.restore(componentId)` -> `POST /components/{id}/restore`, returns
+  the restored `ComponentResponse`. A non-archived component answers 409, which
+  surfaces as `APIError` with `status: 409`.
+- `includeDeleted?: boolean` on `ListComponentsOptions` and a new
+  `GetComponentOptions` second argument on `components.get()`. When `true`,
+  `include_deleted=true` is sent and archived components (with an integer
+  `deleted_at`) are returned instead of being omitted / 404ing.
+- `RefreshMetricsOptions.background` on `metrics.refresh()`, sent as
+  `background=true`; the server returns 202 with `{ status: "started" |
+  "already_running", message }` instead of blocking on the recalculation.
+- `metrics.refreshStatus({ dbId? })` -> `GET /metrics/refresh/status`, typed as
+  `components["schemas"]["MetricsRefreshStatusResponse"]` (`status: idle |
+  running | completed | failed`, `started_at`, `finished_at`, `error`).
+- Exported option types `GetComponentOptions`, `RefreshMetricsOptions` and
+  `RefreshStatusOptions`.
 
 
 ## [0.6.1] - 2026-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- `metrics.refresh()` now returns the response body instead of discarding it:
+  `DayAggregatedMetrics[]` on the default synchronous path (the server has
+  returned this list since 2.8.5), or `MetricsRefreshResponse`
+  (`{ status, message }`) when the server reports `already_running` or when
+  `background: true` is passed. Discriminate with `Array.isArray()`. Callers
+  that ignored the old `void` result are unaffected.
+- `components.delete()` is documented as an archive (soft delete): the server
+  stamps `deleted_at` and keeps the id reserved. It has behaved this way since
+  2.8.5; the JSDoc said "delete".
 - Regenerated `openapi.json` and `src/generated/types.ts` from an AgentOS running
   agno 3.0.0. The committed spec predated 2.8.5 (76 paths); the new capture has
   117 paths and 187 schemas. No route was removed and no schema key used by
@@ -44,15 +53,6 @@ This project follows [Semantic Versioning](https://semver.org/).
 - `AgentOSClient.getConfig()` returns `components["schemas"]["ConfigResponse"]`
   instead of the hand-written `OSConfig`, so `available_models` typechecks as
   `Model[]`.
-- `metrics.refresh()` now returns the response body instead of discarding it:
-  `DayAggregatedMetrics[]` on the default synchronous path (the server has
-  returned this list since 2.8.5), or `MetricsRefreshResponse`
-  (`{ status, message }`) when the server reports `already_running` or when
-  `background: true` is passed. Discriminate with `Array.isArray()`. Callers
-  that ignored the old `void` result are unaffected.
-- `components.delete()` is documented as an archive (soft delete): the server
-  stamps `deleted_at` and keeps the id reserved. It has behaved this way since
-  2.8.5; the JSDoc said "delete".
 
 ### Breaking
 
@@ -89,7 +89,6 @@ Release note: this warrants a minor bump (0.7.0), not a patch.
 
 ### Added
 
-- `GetMetricsOptions.userId`, sent as the `user_id` query param on `GET /metrics`.
 - `client.info()` -> `GET /info`, typed as `components["schemas"]["InfoResponse"]`
   (`os_id`, `name`, `os_version`, `agno_version`, `agent_count`, `team_count`,
   `workflow_count`, `mcp`, `auth_mode`). The only route that reports the running
@@ -109,6 +108,7 @@ Release note: this warrants a minor bump (0.7.0), not a patch.
   running | completed | failed`, `started_at`, `finished_at`, `error`).
 - Exported option types `GetComponentOptions`, `RefreshMetricsOptions` and
   `RefreshStatusOptions`.
+- `GetMetricsOptions.userId`, sent as the `user_id` query param on `GET /metrics`.
 
 
 ## [0.6.1] - 2026-06-05

--- a/README.md
+++ b/README.md
@@ -295,7 +295,33 @@ console.log(metrics);
 
 **Refresh metrics:**
 ```typescript
-await client.metrics.refresh();
+// Synchronous: returns the refreshed DayAggregatedMetrics[] (or
+// { status: "already_running" } if a refresh is already in flight)
+const days = await client.metrics.refresh();
+if (Array.isArray(days)) console.log(`${days.length} days refreshed`);
+
+// Background: 202 with { status: "started" | "already_running", message }
+const started = await client.metrics.refresh({ background: true });
+
+// Poll the most recent refresh: idle | running | completed | failed
+const status = await client.metrics.refreshStatus();
+console.log(status.status, status.finished_at, status.error);
+```
+
+### Components
+
+```typescript
+// Archived (soft-deleted) components are hidden by default
+const active = await client.components.list();
+const all = await client.components.list({ includeDeleted: true });
+
+// delete() archives: deleted_at is stamped and the id stays reserved
+await client.components.delete('component-123');
+const archived = await client.components.get('component-123', { includeDeleted: true });
+console.log(archived.deleted_at);
+
+// restore() undoes the archive; 409 (APIError) if it was not archived
+const restored = await client.components.restore('component-123');
 ```
 
 ## Streaming
@@ -580,7 +606,8 @@ new AgentOSClient(options: AgentOSClientOptions)
 
 **Methods:**
 - `getConfig(): Promise<ConfigResponse>` - Get server configuration (`components['schemas']['ConfigResponse']`)
-- `health(): Promise<HealthStatus>` - Check API health status
+- `health(): Promise<HealthStatus>` - Check API health status (`{ status, instantiated_at }`, typed from `components['schemas']['HealthResponse']`)
+- `info(): Promise<InfoResponse>` - Get OS metadata: `os_version`, `agno_version`, component counts, MCP and `auth_mode` (`components['schemas']['InfoResponse']`)
 
 ### Resource Namespaces
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,7 @@ import type {
 } from "./types";
 
 type ConfigResponse = components["schemas"]["ConfigResponse"];
+type InfoResponse = components["schemas"]["InfoResponse"];
 
 /**
  * AgentOS API client
@@ -112,6 +113,23 @@ export class AgentOSClient {
    */
   async health(): Promise<HealthStatus> {
     return this.request<HealthStatus>("GET", "/health");
+  }
+
+  /**
+   * Get lightweight OS metadata from `GET /info`
+   *
+   * Returns `os_id`, `name`, `os_version`, `agno_version`, component counts,
+   * MCP availability and the effective `auth_mode`. This is the only route
+   * that reports which AgentOS version is running.
+   *
+   * @example
+   * ```typescript
+   * const info = await client.info();
+   * console.log(info.os_version, info.agno_version);
+   * ```
+   */
+  async info(): Promise<InfoResponse> {
+    return this.request<InfoResponse>("GET", "/info");
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export { ComponentsResource } from "./resources/components";
 export type {
   CreateComponentOptions,
   CreateConfigOptions,
+  GetComponentOptions,
   ListComponentsOptions,
   UpdateComponentOptions,
   UpdateConfigOptions,
@@ -84,7 +85,11 @@ export type {
 } from "./resources/memories";
 
 export { MetricsResource } from "./resources/metrics";
-export type { GetMetricsOptions } from "./resources/metrics";
+export type {
+  GetMetricsOptions,
+  RefreshMetricsOptions,
+  RefreshStatusOptions,
+} from "./resources/metrics";
 
 export { ModelsResource } from "./resources/models";
 

--- a/src/resources/components.ts
+++ b/src/resources/components.ts
@@ -22,6 +22,22 @@ export interface ListComponentsOptions {
   page?: number;
   /** Number of items per page */
   limit?: number;
+  /**
+   * Also list archived (soft-deleted) components. Archived rows carry a
+   * `deleted_at` timestamp and are omitted by default.
+   */
+  includeDeleted?: boolean;
+}
+
+/**
+ * Options for fetching a single component
+ */
+export interface GetComponentOptions {
+  /**
+   * Also return the component if it is archived (soft-deleted). Archived
+   * components 404 by default.
+   */
+  includeDeleted?: boolean;
 }
 
 /**
@@ -104,7 +120,7 @@ export interface UpdateConfigOptions {
  * Resource class for component operations
  *
  * Provides methods to:
- * - List, create, get, update, and delete components
+ * - List, create, get, update, archive (delete) and restore components
  * - Manage component configurations and versioning
  *
  * @example
@@ -156,6 +172,9 @@ export class ComponentsResource {
     }
     if (options?.limit !== undefined) {
       params.append("limit", String(options.limit));
+    }
+    if (options?.includeDeleted) {
+      params.append("include_deleted", "true");
     }
 
     const queryString = params.toString();
@@ -216,19 +235,30 @@ export class ComponentsResource {
    * Get component details by ID
    *
    * @param componentId - The unique identifier for the component
+   * @param options - Pass `includeDeleted: true` to also return an archived component
    * @returns Component details
    *
    * @example
    * ```typescript
    * const component = await client.components.get('component-123');
    * console.log(component.name, component.component_type);
+   *
+   * // Fetch an archived component (404 without the flag)
+   * const archived = await client.components.get('component-123', {
+   *   includeDeleted: true,
+   * });
+   * console.log(archived.deleted_at);
    * ```
    */
-  async get(componentId: string): Promise<ComponentResponse> {
-    return this.client.request<ComponentResponse>(
-      "GET",
-      `/components/${encodeURIComponent(componentId)}`,
-    );
+  async get(
+    componentId: string,
+    options?: GetComponentOptions,
+  ): Promise<ComponentResponse> {
+    const base = `/components/${encodeURIComponent(componentId)}`;
+    const path = options?.includeDeleted
+      ? `${base}?include_deleted=true`
+      : base;
+    return this.client.request<ComponentResponse>("GET", path);
   }
 
   /**
@@ -276,7 +306,12 @@ export class ComponentsResource {
   }
 
   /**
-   * Delete a component
+   * Archive a component
+   *
+   * The server soft-deletes: the row is stamped with `deleted_at` and its
+   * `component_id` stays reserved. Archived components disappear from
+   * `list()` and 404 on `get()` unless `includeDeleted: true` is passed.
+   * Undo with {@link restore}.
    *
    * @param componentId - The unique identifier for the component
    *
@@ -289,6 +324,29 @@ export class ComponentsResource {
     await this.client.request<void>(
       "DELETE",
       `/components/${encodeURIComponent(componentId)}`,
+    );
+  }
+
+  /**
+   * Restore an archived (soft-deleted) component
+   *
+   * Clears `deleted_at` and returns the component. The server answers 404 for
+   * an unknown id and 409 (surfaced as `APIError` with `status: 409`) when the
+   * component is not archived.
+   *
+   * @param componentId - The unique identifier for the component
+   * @returns The restored component
+   *
+   * @example
+   * ```typescript
+   * const component = await client.components.restore('component-123');
+   * console.log(component.deleted_at); // null
+   * ```
+   */
+  async restore(componentId: string): Promise<ComponentResponse> {
+    return this.client.request<ComponentResponse>(
+      "POST",
+      `/components/${encodeURIComponent(componentId)}/restore`,
     );
   }
 

--- a/src/resources/metrics.ts
+++ b/src/resources/metrics.ts
@@ -3,6 +3,10 @@ import type { components } from "../generated/types";
 
 // Extract types from generated schemas
 type MetricsResponse = components["schemas"]["MetricsResponse"];
+type DayAggregatedMetrics = components["schemas"]["DayAggregatedMetrics"];
+type MetricsRefreshResponse = components["schemas"]["MetricsRefreshResponse"];
+type MetricsRefreshStatusResponse =
+  components["schemas"]["MetricsRefreshStatusResponse"];
 
 /**
  * Options for retrieving metrics with date filtering
@@ -14,6 +18,28 @@ export interface GetMetricsOptions {
   endingDate?: string;
   /** Filter metrics to a single user */
   userId?: string;
+  /** Database ID */
+  dbId?: string;
+}
+
+/**
+ * Options for triggering a metrics refresh
+ */
+export interface RefreshMetricsOptions {
+  /** Database ID */
+  dbId?: string;
+  /**
+   * Run the refresh in the background. The server answers 202 immediately
+   * with `{ status: "started" | "already_running", message }`; poll
+   * {@link MetricsResource.refreshStatus} (or `get()`) for the result.
+   */
+  background?: boolean;
+}
+
+/**
+ * Options for reading the metrics refresh status
+ */
+export interface RefreshStatusOptions {
   /** Database ID */
   dbId?: string;
 }
@@ -36,8 +62,8 @@ export interface GetMetricsOptions {
  *   endingDate: '2024-01-31',
  * });
  *
- * // Trigger metrics refresh
- * await client.metrics.refresh();
+ * // Recalculate metrics and get the refreshed day list back
+ * const days = await client.metrics.refresh();
  * ```
  */
 export class MetricsResource {
@@ -86,24 +112,79 @@ export class MetricsResource {
   /**
    * Trigger metrics refresh
    *
-   * Initiates recalculation of metrics from source data.
+   * Recalculates metrics from source data. By default the server runs the
+   * refresh synchronously and returns the refreshed `DayAggregatedMetrics[]`.
+   * With `background: true` it returns 202 immediately with a
+   * `MetricsRefreshResponse` (`status: "started"`). Either mode answers
+   * `{ status: "already_running" }` instead of starting a second refresh for
+   * the same database, so discriminate with `Array.isArray()`.
+   *
+   * @param options - Database ID and background flag
+   * @returns The refreshed day list, or a status object
    *
    * @example
    * ```typescript
-   * await client.metrics.refresh();
-   * console.log('Metrics refresh triggered');
+   * const result = await client.metrics.refresh();
+   * if (Array.isArray(result)) {
+   *   console.log(`${result.length} days refreshed`);
+   * } else {
+   *   console.log(result.status); // "already_running"
+   * }
+   *
+   * const started = await client.metrics.refresh({ background: true });
+   * console.log(started.status); // "started" | "already_running"
    * ```
    */
-  async refresh(options?: { dbId?: string }): Promise<void> {
+  async refresh(
+    options?: RefreshMetricsOptions,
+  ): Promise<DayAggregatedMetrics[] | MetricsRefreshResponse> {
     const params = new URLSearchParams();
     if (options?.dbId !== undefined) {
       params.append("db_id", options.dbId);
+    }
+    if (options?.background) {
+      params.append("background", "true");
     }
     const queryString = params.toString();
     const path = queryString
       ? `/metrics/refresh?${queryString}`
       : "/metrics/refresh";
 
-    await this.client.request<void>("POST", path);
+    return this.client.request<DayAggregatedMetrics[] | MetricsRefreshResponse>(
+      "POST",
+      path,
+    );
+  }
+
+  /**
+   * Get the status of the most recent metrics refresh
+   *
+   * `status` is `"idle"` when no refresh has run since the server started,
+   * `"running"` while one is in progress, then `"completed"` or `"failed"`
+   * (with `error` set). Intended for polling after
+   * `refresh({ background: true })`.
+   *
+   * @param options - Database ID
+   * @returns Refresh status with `started_at` / `finished_at` timestamps
+   *
+   * @example
+   * ```typescript
+   * const status = await client.metrics.refreshStatus();
+   * console.log(status.status, status.finished_at);
+   * ```
+   */
+  async refreshStatus(
+    options?: RefreshStatusOptions,
+  ): Promise<MetricsRefreshStatusResponse> {
+    const params = new URLSearchParams();
+    if (options?.dbId !== undefined) {
+      params.append("db_id", options.dbId);
+    }
+    const queryString = params.toString();
+    const path = queryString
+      ? `/metrics/refresh/status?${queryString}`
+      : "/metrics/refresh/status";
+
+    return this.client.request<MetricsRefreshStatusResponse>("GET", path);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { components } from "./generated/types";
+
 /**
  * Configuration options for the AgentOSClient
  */
@@ -43,10 +45,9 @@ export interface RequestOptions {
 }
 
 /**
- * Health status response from /health endpoint
+ * Health status response from `GET /health`
+ *
+ * Mirrors the server's `HealthResponse` schema: `status` (`"ok"` on a healthy
+ * instance) and `instantiated_at` (ISO-8601 timestamp of process start).
  */
-export interface HealthStatus {
-  status: "healthy" | "degraded" | "unhealthy";
-  timestamp: string;
-  details?: Record<string, unknown>;
-}
+export type HealthStatus = components["schemas"]["HealthResponse"];

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -125,8 +125,8 @@ describe("AgentOSClient", () => {
   describe("health", () => {
     it("should fetch health from /health endpoint", async () => {
       const mockHealth = {
-        status: "healthy",
-        timestamp: "2026-01-31T00:00:00Z",
+        status: "ok",
+        instantiated_at: "2026-01-31T00:00:00Z",
       };
       mockRequestWithRetry.mockResolvedValueOnce(mockHealth);
 
@@ -145,13 +145,11 @@ describe("AgentOSClient", () => {
       );
     });
 
-    it("should handle degraded health status", async () => {
-      const mockHealth = {
-        status: "degraded",
-        timestamp: "2026-01-31T00:00:00Z",
-        details: { database: "slow" },
-      };
-      mockRequestWithRetry.mockResolvedValueOnce(mockHealth);
+    it("exposes the HealthResponse wire shape without a cast", async () => {
+      mockRequestWithRetry.mockResolvedValueOnce({
+        status: "ok",
+        instantiated_at: "2026-01-31T00:00:00Z",
+      });
 
       const client = new AgentOSClient({
         baseUrl: "https://api.example.com",
@@ -159,8 +157,81 @@ describe("AgentOSClient", () => {
 
       const health = await client.health();
 
-      expect(health.status).toBe("degraded");
-      expect(health.details).toEqual({ database: "slow" });
+      // Typechecks against components["schemas"]["HealthResponse"]
+      const instantiatedAt: string = health.instantiated_at;
+      expect(instantiatedAt).toBe("2026-01-31T00:00:00Z");
+      expect(health.status).toBe("ok");
+    });
+  });
+
+  describe("info", () => {
+    it("should fetch OS metadata from /info endpoint", async () => {
+      const mockInfo = {
+        os_id: "test-os",
+        name: "AgentOS",
+        os_version: "1.0.0",
+        agno_version: "3.0.0",
+        agent_count: 4,
+        team_count: 1,
+        workflow_count: 0,
+        mcp: { enabled: true, path: "/mcp", oauth: null },
+        auth_mode: "none",
+      };
+      mockRequestWithRetry.mockResolvedValueOnce(mockInfo);
+
+      const client = new AgentOSClient({
+        baseUrl: "https://api.example.com",
+      });
+
+      const info = await client.info();
+
+      expect(info).toEqual(mockInfo);
+      expect(info.os_version).toBe("1.0.0");
+      expect(info.agno_version).toBe("3.0.0");
+      expect(mockRequestWithRetry).toHaveBeenCalledWith(
+        "https://api.example.com/info",
+        expect.objectContaining({ method: "GET" }),
+        2, // default maxRetries
+        30000, // default timeout
+      );
+    });
+
+    it("should send the Bearer token on /info when apiKey is set", async () => {
+      mockRequestWithRetry.mockResolvedValueOnce({
+        os_id: "test-os",
+        os_version: "1.0.0",
+        agno_version: "3.0.0",
+      });
+
+      const client = new AgentOSClient({
+        baseUrl: "https://api.example.com",
+        apiKey: "my-secret-key",
+      });
+
+      await client.info();
+
+      expect(mockRequestWithRetry).toHaveBeenCalledWith(
+        "https://api.example.com/info",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer my-secret-key",
+          }),
+        }),
+        expect.any(Number),
+        expect.any(Number),
+      );
+    });
+
+    it("should propagate errors for info", async () => {
+      mockRequestWithRetry.mockRejectedValueOnce(
+        new AuthenticationError("Unauthorized", "req-789"),
+      );
+
+      const client = new AgentOSClient({
+        baseUrl: "https://api.example.com",
+      });
+
+      await expect(client.info()).rejects.toThrow(AuthenticationError);
     });
   });
 
@@ -510,6 +581,16 @@ describe("AgentOSClient", () => {
       expect(client.metrics).toBeDefined();
       expect(typeof client.metrics.get).toBe("function");
       expect(typeof client.metrics.refresh).toBe("function");
+      expect(typeof client.metrics.refreshStatus).toBe("function");
+    });
+
+    it("exposes components resource", () => {
+      const client = new AgentOSClient({ baseUrl: "https://api.example.com" });
+      expect(client.components).toBeDefined();
+      expect(typeof client.components.list).toBe("function");
+      expect(typeof client.components.get).toBe("function");
+      expect(typeof client.components.delete).toBe("function");
+      expect(typeof client.components.restore).toBe("function");
     });
 
     it("agents resource uses client.request for API calls", async () => {

--- a/tests/resources/components.test.ts
+++ b/tests/resources/components.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentOSClient } from "../../src/client";
+import { APIError } from "../../src/errors";
 import { ComponentsResource } from "../../src/resources/components";
 
 describe("ComponentsResource", () => {
@@ -57,6 +58,47 @@ describe("ComponentsResource", () => {
         "GET",
         "/components?page=2&limit=10",
       );
+    });
+
+    it("adds include_deleted=true when includeDeleted is set", async () => {
+      const archived = {
+        component_id: "comp-1",
+        component_type: "agent",
+        created_at: 1_700_000_000,
+        deleted_at: 1_700_000_100,
+      };
+      requestSpy.mockResolvedValueOnce({ data: [archived] });
+
+      const result = await resource.list({ includeDeleted: true });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "GET",
+        "/components?include_deleted=true",
+      );
+      // deleted_at typechecks as number | null | undefined on ComponentResponse
+      const deletedAt: number | null | undefined = result.data[0]?.deleted_at;
+      expect(deletedAt).toBe(1_700_000_100);
+    });
+
+    it("combines include_deleted with other params", async () => {
+      requestSpy.mockResolvedValueOnce({ data: [] });
+
+      await resource.list({ componentType: "agent", includeDeleted: true });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "GET",
+        "/components?component_type=agent&include_deleted=true",
+      );
+    });
+
+    it("omits include_deleted when includeDeleted is false or unset", async () => {
+      requestSpy.mockResolvedValue({ data: [] });
+
+      await resource.list({ includeDeleted: false });
+      await resource.list({});
+
+      expect(requestSpy).toHaveBeenNthCalledWith(1, "GET", "/components");
+      expect(requestSpy).toHaveBeenNthCalledWith(2, "GET", "/components");
     });
 
     it("combines all query params", async () => {
@@ -199,6 +241,40 @@ describe("ComponentsResource", () => {
       );
     });
 
+    it("adds include_deleted=true when includeDeleted is set", async () => {
+      requestSpy.mockResolvedValueOnce({
+        component_id: "comp-1",
+        deleted_at: 1_700_000_100,
+      });
+
+      const result = await resource.get("comp-1", { includeDeleted: true });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "GET",
+        "/components/comp-1?include_deleted=true",
+      );
+      expect(result.deleted_at).toBe(1_700_000_100);
+    });
+
+    it("keeps URL-encoding when include_deleted is appended", async () => {
+      requestSpy.mockResolvedValueOnce({ component_id: "comp/special" });
+
+      await resource.get("comp/special", { includeDeleted: true });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "GET",
+        "/components/comp%2Fspecial?include_deleted=true",
+      );
+    });
+
+    it("omits include_deleted when includeDeleted is false", async () => {
+      requestSpy.mockResolvedValueOnce({ component_id: "comp-1" });
+
+      await resource.get("comp-1", { includeDeleted: false });
+
+      expect(requestSpy).toHaveBeenCalledWith("GET", "/components/comp-1");
+    });
+
     it("propagates errors from client.request", async () => {
       requestSpy.mockRejectedValueOnce(new Error("Not found"));
 
@@ -300,6 +376,58 @@ describe("ComponentsResource", () => {
       requestSpy.mockRejectedValueOnce(new Error("Not found"));
 
       await expect(resource.delete("nonexistent")).rejects.toThrow("Not found");
+    });
+  });
+
+  describe("restore()", () => {
+    it("sends POST /components/{component_id}/restore and returns the component", async () => {
+      const mockComponent = {
+        component_id: "comp-1",
+        component_type: "agent",
+        name: "My Agent",
+        created_at: 1_700_000_000,
+        deleted_at: null,
+      };
+      requestSpy.mockResolvedValueOnce(mockComponent);
+
+      const result = await resource.restore("comp-1");
+
+      expect(result).toEqual(mockComponent);
+      expect(requestSpy).toHaveBeenCalledWith(
+        "POST",
+        "/components/comp-1/restore",
+      );
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("URL-encodes component ID", async () => {
+      requestSpy.mockResolvedValueOnce({ component_id: "comp/special" });
+
+      await resource.restore("comp/special");
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "POST",
+        "/components/comp%2Fspecial/restore",
+      );
+    });
+
+    it("surfaces a 409 (not archived) as APIError with status 409", async () => {
+      requestSpy.mockRejectedValueOnce(
+        new APIError(409, "Component is not archived"),
+      );
+
+      const promise = resource.restore("comp-1");
+
+      await expect(promise).rejects.toBeInstanceOf(APIError);
+      await expect(promise).rejects.toMatchObject({ status: 409 });
+    });
+
+    it("propagates errors from client.request", async () => {
+      requestSpy.mockRejectedValueOnce(new Error("Not found"));
+
+      await expect(resource.restore("nonexistent")).rejects.toThrow(
+        "Not found",
+      );
     });
   });
 

--- a/tests/resources/metrics.test.ts
+++ b/tests/resources/metrics.test.ts
@@ -132,8 +132,26 @@ describe("MetricsResource", () => {
   });
 
   describe("refresh()", () => {
+    const dayList = [
+      {
+        id: "2025-08-12_daily",
+        agent_runs_count: 2,
+        agent_sessions_count: 2,
+        team_runs_count: 0,
+        team_sessions_count: 0,
+        workflow_runs_count: 0,
+        workflow_sessions_count: 0,
+        users_count: 1,
+        token_metrics: { input_tokens: 256, output_tokens: 441 },
+        model_metrics: [],
+        date: "2025-08-12T00:00:00Z",
+        created_at: "2025-08-12T08:01:47Z",
+        updated_at: "2025-08-12T08:01:47Z",
+      },
+    ];
+
     it("calls POST /metrics/refresh with no params", async () => {
-      requestSpy.mockResolvedValueOnce(undefined);
+      requestSpy.mockResolvedValueOnce(dayList);
 
       await resource.refresh();
 
@@ -141,12 +159,64 @@ describe("MetricsResource", () => {
       expect(requestSpy).toHaveBeenCalledTimes(1);
     });
 
-    it("returns void/undefined", async () => {
-      requestSpy.mockResolvedValueOnce(undefined);
+    it("returns the refreshed DayAggregatedMetrics list", async () => {
+      requestSpy.mockResolvedValueOnce(dayList);
 
       const result = await resource.refresh();
 
-      expect(result).toBeUndefined();
+      expect(result).toEqual(dayList);
+      expect(Array.isArray(result)).toBe(true);
+      if (Array.isArray(result)) {
+        expect(result[0]?.agent_runs_count).toBe(2);
+      }
+    });
+
+    it("returns already_running when a sync refresh is already in flight", async () => {
+      const body = {
+        status: "already_running",
+        message: "A metrics refresh is already in progress",
+      };
+      requestSpy.mockResolvedValueOnce(body);
+
+      const result = await resource.refresh();
+
+      expect(result).toEqual(body);
+      expect(Array.isArray(result)).toBe(false);
+    });
+
+    it("appends background=true and returns the 202 status body", async () => {
+      const body = {
+        status: "started",
+        message: "Metrics refresh started in background",
+      };
+      requestSpy.mockResolvedValueOnce(body);
+
+      const result = await resource.refresh({ background: true });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "POST",
+        "/metrics/refresh?background=true",
+      );
+      expect(result).toEqual(body);
+    });
+
+    it("combines db_id and background query params", async () => {
+      requestSpy.mockResolvedValueOnce({ status: "started" });
+
+      await resource.refresh({ dbId: "mydb", background: true });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "POST",
+        "/metrics/refresh?db_id=mydb&background=true",
+      );
+    });
+
+    it("omits background when false", async () => {
+      requestSpy.mockResolvedValueOnce([]);
+
+      await resource.refresh({ background: false });
+
+      expect(requestSpy).toHaveBeenCalledWith("POST", "/metrics/refresh");
     });
 
     it("propagates errors from client.request", async () => {
@@ -156,20 +226,68 @@ describe("MetricsResource", () => {
     });
 
     it("adds db_id query param when dbId provided", async () => {
-      requestSpy.mockResolvedValueOnce(undefined);
+      requestSpy.mockResolvedValueOnce([]);
 
       await resource.refresh({ dbId: "mydb" });
 
-      const callPath = requestSpy.mock.calls[0][1];
-      expect(callPath).toContain("db_id=mydb");
+      expect(requestSpy).toHaveBeenCalledWith(
+        "POST",
+        "/metrics/refresh?db_id=mydb",
+      );
+    });
+  });
+
+  describe("refreshStatus()", () => {
+    it("calls GET /metrics/refresh/status with no params", async () => {
+      const body = {
+        status: "idle",
+        started_at: null,
+        finished_at: null,
+        error: null,
+      };
+      requestSpy.mockResolvedValueOnce(body);
+
+      const result = await resource.refreshStatus();
+
+      expect(result).toEqual(body);
+      expect(requestSpy).toHaveBeenCalledWith("GET", "/metrics/refresh/status");
+      expect(requestSpy).toHaveBeenCalledTimes(1);
     });
 
-    it("calls POST /metrics/refresh with no query params when no options", async () => {
-      requestSpy.mockResolvedValueOnce(undefined);
+    it("returns the completed status shape", async () => {
+      const body = {
+        status: "completed",
+        started_at: "2025-08-12T08:01:47Z",
+        finished_at: "2025-08-12T08:01:49Z",
+        error: null,
+      };
+      requestSpy.mockResolvedValueOnce(body);
 
-      await resource.refresh();
+      const result = await resource.refreshStatus();
 
-      expect(requestSpy).toHaveBeenCalledWith("POST", "/metrics/refresh");
+      expect(result.status).toBe("completed");
+      expect(result.started_at).toBe("2025-08-12T08:01:47Z");
+      expect(result.finished_at).toBe("2025-08-12T08:01:49Z");
+      expect(result.error).toBeNull();
+    });
+
+    it("adds db_id query param when dbId provided", async () => {
+      requestSpy.mockResolvedValueOnce({ status: "running" });
+
+      await resource.refreshStatus({ dbId: "mydb" });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "GET",
+        "/metrics/refresh/status?db_id=mydb",
+      );
+    });
+
+    it("propagates errors from client.request", async () => {
+      requestSpy.mockRejectedValueOnce(new Error("Database not found"));
+
+      await expect(resource.refreshStatus()).rejects.toThrow(
+        "Database not found",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Exposes the agno 3.0 routes and params that the regenerated types (#12) already describe but no hand-written method reached. Three issues, one PR, because they are the same sweep: #9 depends on #7's `restore()`, and #8 is the sibling metrics contract.

Consumers: ixora-cli#122 (`components restore` / `--include-deleted`) and ixora-cli#119 (`metrics refresh` output / `--background` / status) build on this. Once it publishes, ixora-cli's `src/agentos/health.ts` can drop its `unknown` cast on `health()`.

## Changes

**#7 — `client.info()`, `components.restore()`, `HealthStatus` type**
- `client.info(): Promise<InfoResponse>` -> `GET /info`, typed from `components["schemas"]["InfoResponse"]` (`os_id`, `name`, `os_version`, `agno_version`, counts, `mcp`, `auth_mode`).
- `HealthStatus` is now an alias of `components["schemas"]["HealthResponse"]` = `{ status: string; instantiated_at: string }`. Exported name kept. The old `{ status: "healthy"|"degraded"|"unhealthy", timestamp, details? }` never matched the wire, so this is recorded under **Breaking** in the CHANGELOG.
- `components.restore(id): Promise<ComponentResponse>` -> `POST /components/{id}/restore`. 404 unknown id; 409 not-archived arrives as `APIError` with `status: 409` (no new error subclass, per the issue).

**#9 — `includeDeleted`**
- `ListComponentsOptions.includeDeleted?: boolean` and a new `GetComponentOptions` second argument on `components.get()`. When `true`, `include_deleted=true` is appended; `false`/omitted sends nothing.
- `components.delete()` JSDoc reworded: it archives (`deleted_at` stamped, id reserved), undo with `restore()`.

**#8 — metrics refresh**
- `metrics.refresh()` returns `Promise<DayAggregatedMetrics[] | MetricsRefreshResponse>` instead of `Promise<void>`; discriminate with `Array.isArray()` (the sync path can also answer `{ status: "already_running" }`).
- `RefreshMetricsOptions.background` sends `background=true` for the 202 `{ status: "started" | "already_running", message }` path.
- `metrics.refreshStatus({ dbId? })` -> `GET /metrics/refresh/status`, typed `MetricsRefreshStatusResponse`.

Also: new exported option types `GetComponentOptions`, `RefreshMetricsOptions`, `RefreshStatusOptions`; README (`### Components` section, metrics refresh example, client method list) and CHANGELOG `[Unreleased]` entries (Added / Changed / Breaking).

## Verification

```
npm run lint       # biome: 33 files, no errors
npm run typecheck  # tsc --noEmit: clean
npm test           # 26 files, 850 tests passed
npm run build      # tsup CJS/ESM/DTS success
```

New/updated tests: `tests/client.test.ts` (health wire shape without a cast, `info()` incl. bearer + error propagation), `tests/resources/components.test.ts` (`list`/`get` with and without `include_deleted`, encoding preserved, `restore()` incl. 409 as `APIError`), `tests/resources/metrics.test.ts` (day list, `already_running`, `background=true`, param combination, `refreshStatus()` idle/completed/`db_id`).

### Live check — agno 3.0.0 stack at `localhost:8050` (auth off), SDK-driven from the built `dist/`

`npx tsx` script imports `AgentOSClient`/`APIError` from this branch's `dist/index.js`; every value below is the observed response (the only script-side derivation is `typeof`). The component is created with a unique id, archived, inspected, restored, restored again, then re-archived so the shared stack is left as found.

```
## client.info()
{ "os_version": "1.0.0", "agno_version": "3.0.0", "auth_mode": "none", "agent_count": 4 }

## client.health()            (const instantiatedAt: string = health.instantiated_at — no cast)
{ "status": "ok", "instantiated_at": "2026-09-04T15:25:00.124305Z" }

## components.create({ componentType: "agent", componentId: id })
{ "component_id": "sdk-s2-restore-check-1788535528011", "deleted_at": null }

## components.delete(id); components.get(id)          -> default hides archived rows
{ "error": "_NotFoundError", "status": 404 }

## components.list({ includeDeleted: true }) -> our row
{ "component_id": "sdk-s2-restore-check-1788535528011", "deleted_at": 1788535528, "typeof_deleted_at": "number" }

## components.get(id, { includeDeleted: true })
{ "component_id": "sdk-s2-restore-check-1788535528011", "deleted_at": 1788535528 }

## components.restore(id)
{ "component_id": "sdk-s2-restore-check-1788535528011", "deleted_at": null }

## components.restore(id) again
{ "error": "_APIError", "status": 409, "message": "Component is not archived" }

## cleanup: delete(id) again; visible in default list()?
false

## metrics.refresh()                                   -> sync path returns the day list
{ "isArray": true, "days": 0, "first": null }

## metrics.refresh({ background: true })               -> 202 body
{ "status": "started", "message": "Metrics refresh started in background" }

## metrics.refreshStatus() immediately
{ "status": "running", "started_at": "2026-09-04T15:25:28.396569Z", "finished_at": null, "error": null }

## metrics.refreshStatus() after 1.5s
{ "status": "completed", "started_at": "2026-09-04T15:25:28.396569Z", "finished_at": "2026-09-04T15:25:28.402185Z", "error": null }
```

The same script was also run against a vanilla agno 3.0.0 `AgentOS` (`SqliteDb`, one agent, no ixora routers) started natively on the host while the shared stack was temporarily unresponsive; the output was identical apart from ids/timestamps and `os_version: "0.0.1"` / `agent_count: 1`, so the contracts hold on a stock agno server as well as an ixora stack.

Closes #7
Closes #9
Closes #8
