### PR TITLE
fix(resources): match sessions.create/rename, workflows.getRun and teams.continue to their AgentOS routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,8 +67,37 @@ warnings:
 - The hand-written `OSConfig` type is no longer exported. It never matched the
   server's `/config` payload; use `components["schemas"]["ConfigResponse"]`
   instead. `AgentOSClient.getConfig()` returns that type now.
+- `workflows.getRun(workflowId, runId, sessionId)` takes a required positional
+  `sessionId` (third argument), matching `agents.getRun` / `teams.getRun`.
+  `GET /workflows/{id}/runs/{run_id}` declares `session_id` as a required
+  query parameter, so the old two-argument call always 422'd.
+- `CreateSessionOptions.type` is `"agent" | "team" | "workflow"` (exported as
+  `SessionType`) instead of `string` — the only values `POST /sessions?type=`
+  accepts, and the SDK now needs it to pick the `agent_id` / `team_id` /
+  `workflow_id` body field.
 
 Release note: this warrants a minor bump (0.7.0), not a patch.
+
+### Fixed
+
+- `sessions.create()` now matches `POST /sessions`: `type` and `db_id` go in
+  the query string and the JSON body is a `CreateSessionRequest`
+  (`session_name`, `user_id`, and `componentId` mapped to `agent_id` /
+  `team_id` / `workflow_id`). It used to send everything as a JSON body the
+  route ignored, so `create({ type: 'team', componentId, name })` returned
+  200 but persisted an unnamed agent session with no component id.
+- `sessions.rename()` sends `{ session_name }` (the route's `Body(embed=True)`
+  field) instead of `{ name }`, which 422'd.
+- `teams.continue()` sends human-in-the-loop resolutions as the
+  `requirements` form field that `POST /teams/{id}/runs/{run_id}/continue`
+  reads. It used to post `tools`, which only the agent route reads; the team
+  route dropped it silently, so an approved tool was never marked resolved and
+  the run paused again on the same call. `TeamContinueOptions` gains
+  `requirements` (JSON array of the RunPaused `requirements[]` entries with
+  `tool_execution.confirmed` / `confirmation` stamped) and `input` (follow-up
+  message). `tools` is deprecated but still accepted: each entry is wrapped as
+  `{ tool_execution: entry }` and sent as `requirements`, and it is never
+  posted as `tools`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -146,12 +146,20 @@ console.log(result);
 
 **Create a new session:**
 ```typescript
+// type selects the route's ?type= query and which of agent_id / team_id /
+// workflow_id carries componentId in the CreateSessionRequest body
 const session = await client.sessions.create({
-  userId: 'user-123',
-  agentId: 'agent-456',
-  sessionName: 'Customer Support Chat'
+  type: 'team',
+  componentId: 'team-456',
+  name: 'Customer Support Chat',
+  userId: 'user-123'
 });
-console.log(session.id);
+console.log(session.session_id);
+```
+
+**Rename a session:**
+```typescript
+await client.sessions.rename('session-id', 'New name');
 ```
 
 **List sessions with filtering:**

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ export type {
   CreateSessionOptions,
   DeleteAllSessionsOptions,
   ListSessionsOptions,
+  SessionType,
   UpdateSessionOptions,
 } from "./resources/sessions";
 

--- a/src/resources/sessions.ts
+++ b/src/resources/sessions.ts
@@ -5,6 +5,23 @@ import type { components } from "../generated/types";
 type SessionSchema = components["schemas"]["SessionSchema"];
 type PaginatedResponse =
   components["schemas"]["PaginatedResponse_SessionSchema_"];
+type CreateSessionRequest = components["schemas"]["CreateSessionRequest"];
+type RenameSessionBody = components["schemas"]["Body_rename_session"];
+
+/**
+ * Session type accepted by `POST /sessions?type=`
+ */
+export type SessionType = "agent" | "team" | "workflow";
+
+/** `CreateSessionRequest` field that carries the component ID for each session type */
+const COMPONENT_ID_FIELD: Record<
+  SessionType,
+  "agent_id" | "team_id" | "workflow_id"
+> = {
+  agent: "agent_id",
+  team: "team_id",
+  workflow: "workflow_id",
+};
 
 /**
  * Options for listing sessions
@@ -35,7 +52,7 @@ export interface ListSessionsOptions {
  */
 export interface CreateSessionOptions {
   /** Session type (agent, team, or workflow) */
-  type: string;
+  type: SessionType;
   /** Component ID to associate with session */
   componentId: string;
   /** Optional session name */
@@ -228,22 +245,30 @@ export class SessionsResource {
    * ```
    */
   async create(options: CreateSessionOptions): Promise<SessionSchema> {
-    const body: Record<string, unknown> = {
-      type: options.type,
-      component_id: options.componentId,
-    };
+    // The route reads `type` and `db_id` from the query; the JSON body is a
+    // CreateSessionRequest, which carries the component ID as agent_id /
+    // team_id / workflow_id.
+    const params = new URLSearchParams();
+    params.append("type", options.type);
+    if (options.dbId !== undefined) {
+      params.append("db_id", options.dbId);
+    }
+
+    const body: CreateSessionRequest = {};
+    body[COMPONENT_ID_FIELD[options.type]] = options.componentId;
 
     if (options.name !== undefined) {
-      body.name = options.name;
+      body.session_name = options.name;
     }
     if (options.userId !== undefined) {
       body.user_id = options.userId;
     }
-    if (options.dbId !== undefined) {
-      body.db_id = options.dbId;
-    }
 
-    return this.client.request<SessionSchema>("POST", "/sessions", { body });
+    return this.client.request<SessionSchema>(
+      "POST",
+      `/sessions?${params.toString()}`,
+      { body },
+    );
   }
 
   /**
@@ -258,7 +283,7 @@ export class SessionsResource {
    * ```
    */
   async rename(sessionId: string, name: string): Promise<void> {
-    const body = { name };
+    const body: RenameSessionBody = { session_name: name };
 
     await this.client.request<void>(
       "POST",

--- a/src/resources/teams.ts
+++ b/src/resources/teams.ts
@@ -56,16 +56,53 @@ export interface TeamStreamRunOptions {
 
 /**
  * Options for continuing a paused team run
+ *
+ * The team continue route resolves human-in-the-loop pauses from the
+ * `requirements` form field (the agent route's `tools` field is ignored
+ * here). Send the `requirements[]` entries from the RunPaused event back
+ * with the decision stamped: `tool_execution.confirmed: true | false`
+ * (optionally `tool_execution.confirmation_note`), or the requirement-level
+ * `confirmation`. Keep each entry's `id` and `tool_execution.tool_call_id`
+ * so the server can bind it to the stored requirement.
  */
 export interface TeamContinueOptions {
-  /** JSON string containing array of tool execution results */
-  tools: string;
+  /**
+   * JSON string containing an array of RunRequirement entries with their
+   * resolution (see interface doc). May be empty when an admin-required
+   * approval has already been resolved server-side.
+   */
+  requirements?: string;
+  /** Optional follow-up user message appended to the run before resuming */
+  input?: string;
+  /**
+   * @deprecated Use `requirements`. JSON string containing an array of tool
+   * executions; each entry is wrapped as `{ tool_execution: entry }` and sent
+   * as `requirements`. Ignored when `requirements` is provided.
+   */
+  tools?: string;
   /** Optional session ID */
   sessionId?: string;
   /** Optional user ID */
   userId?: string;
   /** Whether to stream the response (default: true) */
   stream?: boolean;
+}
+
+/**
+ * Wrap a legacy `tools` payload (array of tool executions) into the
+ * `requirements` shape the team route reads: `[{ tool_execution: entry }]`.
+ * The server binds each entry to the stored requirement by `tool_call_id`.
+ */
+function wrapToolsAsRequirements(tools: string): string {
+  const entries: unknown = JSON.parse(tools);
+  if (!Array.isArray(entries)) {
+    throw new TypeError(
+      "TeamContinueOptions.tools must be a JSON array of tool executions",
+    );
+  }
+  return JSON.stringify(
+    entries.map((tool_execution: unknown) => ({ tool_execution })),
+  );
 }
 
 /**
@@ -271,12 +308,27 @@ export class TeamsResource {
   }
 
   /**
-   * Continue a paused team run with tool results.
+   * Continue a paused team run with resolved requirements.
    *
    * @param teamId - The team identifier
    * @param runId - The run identifier to continue
-   * @param options - Continue options including tool results
+   * @param options - Continue options including the resolved requirements
    * @returns AgentStream if streaming, otherwise the run result
+   *
+   * @example
+   * ```typescript
+   * // `paused` is the RunPaused event; approve every requirement
+   * const requirements = JSON.stringify(
+   *   paused.requirements.map((r) => ({
+   *     ...r,
+   *     tool_execution: { ...r.tool_execution, confirmed: true },
+   *   })),
+   * );
+   * const stream = await client.teams.continue('team-id', paused.run_id, {
+   *   requirements,
+   *   sessionId: paused.session_id,
+   * });
+   * ```
    */
   async continue(
     teamId: string,
@@ -284,7 +336,17 @@ export class TeamsResource {
     options: TeamContinueOptions,
   ): Promise<AgentStream | unknown> {
     const formData = new FormData();
-    formData.append("tools", options.tools);
+    const requirements =
+      options.requirements ??
+      (options.tools !== undefined
+        ? wrapToolsAsRequirements(options.tools)
+        : undefined);
+    if (requirements !== undefined) {
+      formData.append("requirements", requirements);
+    }
+    if (options.input !== undefined) {
+      formData.append("input", options.input);
+    }
     formData.append("stream", String(options.stream ?? true));
 
     if (options.sessionId) {

--- a/src/resources/workflows.ts
+++ b/src/resources/workflows.ts
@@ -320,18 +320,25 @@ export class WorkflowsResource {
    *
    * @param workflowId - The unique identifier for the workflow
    * @param runId - The unique identifier for the run
+   * @param sessionId - The session ID the run belongs to
    * @returns The run result
    *
    * @example
    * ```typescript
-   * const run = await client.workflows.getRun('workflow-id', 'run-id');
+   * const run = await client.workflows.getRun('workflow-id', 'run-id', 'session-123');
    * console.log(run);
    * ```
    */
-  async getRun(workflowId: string, runId: string): Promise<unknown> {
+  async getRun(
+    workflowId: string,
+    runId: string,
+    sessionId: string,
+  ): Promise<unknown> {
+    const params = new URLSearchParams();
+    params.append("session_id", sessionId);
     return this.client.request<unknown>(
       "GET",
-      `/workflows/${encodeURIComponent(workflowId)}/runs/${encodeURIComponent(runId)}`,
+      `/workflows/${encodeURIComponent(workflowId)}/runs/${encodeURIComponent(runId)}?${params.toString()}`,
     );
   }
 }

--- a/tests/resources/sessions.test.ts
+++ b/tests/resources/sessions.test.ts
@@ -287,7 +287,7 @@ describe("SessionsResource", () => {
   });
 
   describe("create()", () => {
-    it("sends POST /sessions with JSON body (not FormData)", async () => {
+    it("sends POST /sessions?type= with a CreateSessionRequest JSON body", async () => {
       const mockSession = {
         session_id: "new-session",
         session_name: "New Session",
@@ -301,12 +301,12 @@ describe("SessionsResource", () => {
 
       expect(result).toEqual(mockSession);
       expect(requestSpy).toHaveBeenCalledTimes(1);
-      expect(requestSpy).toHaveBeenCalledWith("POST", "/sessions", {
-        body: { type: "agent", component_id: "agent-123" },
+      expect(requestSpy).toHaveBeenCalledWith("POST", "/sessions?type=agent", {
+        body: { agent_id: "agent-123" },
       });
     });
 
-    it("includes type and component_id in body object", async () => {
+    it("maps componentId to team_id for team sessions", async () => {
       requestSpy.mockResolvedValueOnce({ session_id: "s1" });
 
       await resource.create({
@@ -314,12 +314,27 @@ describe("SessionsResource", () => {
         componentId: "team-456",
       });
 
-      expect(requestSpy).toHaveBeenCalledWith("POST", "/sessions", {
-        body: { type: "team", component_id: "team-456" },
+      expect(requestSpy).toHaveBeenCalledWith("POST", "/sessions?type=team", {
+        body: { team_id: "team-456" },
       });
     });
 
-    it("includes optional name when provided", async () => {
+    it("maps componentId to workflow_id for workflow sessions", async () => {
+      requestSpy.mockResolvedValueOnce({ session_id: "s1" });
+
+      await resource.create({
+        type: "workflow",
+        componentId: "workflow-789",
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "POST",
+        "/sessions?type=workflow",
+        { body: { workflow_id: "workflow-789" } },
+      );
+    });
+
+    it("sends name as session_name in the body", async () => {
       requestSpy.mockResolvedValueOnce({ session_id: "s1" });
 
       await resource.create({
@@ -329,12 +344,14 @@ describe("SessionsResource", () => {
       });
 
       const callBody = requestSpy.mock.calls[0][2].body;
-      expect(callBody.name).toBe("My Workflow Session");
-      expect(callBody.type).toBe("workflow");
-      expect(callBody.component_id).toBe("workflow-789");
+      expect(callBody.session_name).toBe("My Workflow Session");
+      expect(callBody.workflow_id).toBe("workflow-789");
+      expect(callBody).not.toHaveProperty("name");
+      expect(callBody).not.toHaveProperty("type");
+      expect(callBody).not.toHaveProperty("component_id");
     });
 
-    it("includes optional user_id when provided", async () => {
+    it("includes optional user_id in the body when provided", async () => {
       requestSpy.mockResolvedValueOnce({ session_id: "s1" });
 
       await resource.create({
@@ -347,7 +364,7 @@ describe("SessionsResource", () => {
       expect(callBody.user_id).toBe("user-999");
     });
 
-    it("includes optional db_id when provided", async () => {
+    it("sends dbId as the db_id query param, not in the body", async () => {
       requestSpy.mockResolvedValueOnce({ session_id: "s1" });
 
       await resource.create({
@@ -356,30 +373,33 @@ describe("SessionsResource", () => {
         dbId: "db-888",
       });
 
-      const callBody = requestSpy.mock.calls[0][2].body;
-      expect(callBody.db_id).toBe("db-888");
+      const [, path, { body }] = requestSpy.mock.calls[0];
+      expect(path).toBe("/sessions?type=agent&db_id=db-888");
+      expect(body).not.toHaveProperty("db_id");
     });
 
-    it("includes name, user_id, db_id in body when all provided", async () => {
+    it("splits query and body correctly when all options provided", async () => {
       requestSpy.mockResolvedValueOnce({ session_id: "s1" });
 
       await resource.create({
-        type: "agent",
-        componentId: "agent-123",
+        type: "team",
+        componentId: "team-456",
         name: "Test Session",
         userId: "user-999",
         dbId: "db-888",
       });
 
-      expect(requestSpy).toHaveBeenCalledWith("POST", "/sessions", {
-        body: {
-          type: "agent",
-          component_id: "agent-123",
-          name: "Test Session",
-          user_id: "user-999",
-          db_id: "db-888",
+      expect(requestSpy).toHaveBeenCalledWith(
+        "POST",
+        "/sessions?type=team&db_id=db-888",
+        {
+          body: {
+            team_id: "team-456",
+            session_name: "Test Session",
+            user_id: "user-999",
+          },
         },
-      });
+      );
     });
 
     it("does not include optional fields when undefined", async () => {
@@ -393,17 +413,14 @@ describe("SessionsResource", () => {
         dbId: undefined,
       });
 
-      const callBody = requestSpy.mock.calls[0][2].body;
-      expect(callBody.type).toBe("agent");
-      expect(callBody.component_id).toBe("agent-123");
-      expect(callBody).not.toHaveProperty("name");
-      expect(callBody).not.toHaveProperty("user_id");
-      expect(callBody).not.toHaveProperty("db_id");
+      const [, path, { body }] = requestSpy.mock.calls[0];
+      expect(path).toBe("/sessions?type=agent");
+      expect(body).toEqual({ agent_id: "agent-123" });
     });
   });
 
   describe("rename()", () => {
-    it("sends POST /sessions/{id}/rename with JSON body (not FormData)", async () => {
+    it("sends POST /sessions/{id}/rename with a Body_rename_session JSON body", async () => {
       requestSpy.mockResolvedValueOnce(undefined);
 
       await resource.rename("session-123", "Updated Name");
@@ -412,17 +429,18 @@ describe("SessionsResource", () => {
       expect(requestSpy).toHaveBeenCalledWith(
         "POST",
         "/sessions/session-123/rename",
-        { body: { name: "Updated Name" } },
+        { body: { session_name: "Updated Name" } },
       );
     });
 
-    it("body contains name field as plain object", async () => {
+    it("body contains session_name only (route uses Body(embed=True))", async () => {
       requestSpy.mockResolvedValueOnce(undefined);
 
       await resource.rename("session-456", "New Session Name");
 
       const callBody = requestSpy.mock.calls[0][2].body;
-      expect(callBody).toEqual({ name: "New Session Name" });
+      expect(callBody).toEqual({ session_name: "New Session Name" });
+      expect(callBody).not.toHaveProperty("name");
     });
 
     it("URL-encodes sessionId", async () => {
@@ -433,7 +451,7 @@ describe("SessionsResource", () => {
       expect(requestSpy).toHaveBeenCalledWith(
         "POST",
         "/sessions/session%2Fspecial/rename",
-        { body: { name: "Name" } },
+        { body: { session_name: "Name" } },
       );
     });
   });

--- a/tests/resources/teams.test.ts
+++ b/tests/resources/teams.test.ts
@@ -352,7 +352,7 @@ describe("TeamsResource", () => {
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
       const result = await resource.continue("team-1", "run-123", {
-        tools: "[]",
+        requirements: "[]",
       });
 
       expect(result).toBeInstanceOf(AgentStream);
@@ -375,7 +375,7 @@ describe("TeamsResource", () => {
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
       const result = await resource.continue("team-1", "run-123", {
-        tools: "[]",
+        requirements: "[]",
         stream: true,
       });
 
@@ -387,7 +387,7 @@ describe("TeamsResource", () => {
       requestSpy.mockResolvedValueOnce(mockResult);
 
       const result = await resource.continue("team-1", "run-123", {
-        tools: "[]",
+        requirements: "[]",
         stream: false,
       });
 
@@ -403,16 +403,112 @@ describe("TeamsResource", () => {
       expect(formData.get("stream")).toBe("false");
     });
 
-    it("includes tools parameter", async () => {
+    it("posts requirements as the requirements form field, never tools", async () => {
       const mockResponse = new Response("data: event", { status: 200 });
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
-      const toolsJSON = '[{"name":"get_weather","result":"sunny"}]';
-      await resource.continue("team-1", "run-123", { tools: toolsJSON });
+      const requirementsJSON = JSON.stringify([
+        {
+          id: "req-1",
+          tool_execution: {
+            tool_call_id: "call_1",
+            tool_name: "validate_and_run_sql",
+            confirmed: true,
+          },
+        },
+      ]);
+      await resource.continue("team-1", "run-123", {
+        requirements: requirementsJSON,
+      });
 
       const callArgs = requestStreamSpy.mock.calls[0];
       const formData = callArgs[2].body as FormData;
-      expect(formData.get("tools")).toBe(toolsJSON);
+      expect(formData.get("requirements")).toBe(requirementsJSON);
+      expect(formData.has("tools")).toBe(false);
+    });
+
+    it("wraps legacy tools entries as { tool_execution } requirements", async () => {
+      const mockResponse = new Response("data: event", { status: 200 });
+      requestStreamSpy.mockResolvedValueOnce(mockResponse);
+
+      const tool = {
+        tool_call_id: "call_1",
+        tool_name: "validate_and_run_sql",
+        tool_args: { sql: "SELECT 1" },
+        requires_confirmation: true,
+        confirmed: true,
+      };
+      await resource.continue("team-1", "run-123", {
+        tools: JSON.stringify([tool]),
+      });
+
+      const callArgs = requestStreamSpy.mock.calls[0];
+      const formData = callArgs[2].body as FormData;
+      expect(formData.has("tools")).toBe(false);
+      expect(JSON.parse(formData.get("requirements") as string)).toEqual([
+        { tool_execution: tool },
+      ]);
+    });
+
+    it("prefers requirements over tools when both are provided", async () => {
+      const mockResponse = new Response("data: event", { status: 200 });
+      requestStreamSpy.mockResolvedValueOnce(mockResponse);
+
+      await resource.continue("team-1", "run-123", {
+        requirements: '[{"id":"req-1","confirmation":true}]',
+        tools: '[{"tool_call_id":"call_1","confirmed":false}]',
+      });
+
+      const callArgs = requestStreamSpy.mock.calls[0];
+      const formData = callArgs[2].body as FormData;
+      expect(formData.get("requirements")).toBe(
+        '[{"id":"req-1","confirmation":true}]',
+      );
+      expect(formData.has("tools")).toBe(false);
+    });
+
+    it("throws when tools is not a JSON array", async () => {
+      await expect(
+        resource.continue("team-1", "run-123", { tools: '{"a":1}' }),
+      ).rejects.toThrow(TypeError);
+      expect(requestStreamSpy).not.toHaveBeenCalled();
+    });
+
+    it("omits requirements when neither requirements nor tools is given", async () => {
+      const mockResponse = new Response("data: event", { status: 200 });
+      requestStreamSpy.mockResolvedValueOnce(mockResponse);
+
+      await resource.continue("team-1", "run-123", { input: "go on" });
+
+      const callArgs = requestStreamSpy.mock.calls[0];
+      const formData = callArgs[2].body as FormData;
+      expect(formData.has("requirements")).toBe(false);
+      expect(formData.has("tools")).toBe(false);
+    });
+
+    it("includes input when provided", async () => {
+      const mockResponse = new Response("data: event", { status: 200 });
+      requestStreamSpy.mockResolvedValueOnce(mockResponse);
+
+      await resource.continue("team-1", "run-123", {
+        requirements: "[]",
+        input: "Also summarize the result",
+      });
+
+      const callArgs = requestStreamSpy.mock.calls[0];
+      const formData = callArgs[2].body as FormData;
+      expect(formData.get("input")).toBe("Also summarize the result");
+    });
+
+    it("omits input when not provided", async () => {
+      const mockResponse = new Response("data: event", { status: 200 });
+      requestStreamSpy.mockResolvedValueOnce(mockResponse);
+
+      await resource.continue("team-1", "run-123", { requirements: "[]" });
+
+      const callArgs = requestStreamSpy.mock.calls[0];
+      const formData = callArgs[2].body as FormData;
+      expect(formData.has("input")).toBe(false);
     });
 
     it("includes session_id when provided", async () => {
@@ -420,7 +516,7 @@ describe("TeamsResource", () => {
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
       await resource.continue("team-1", "run-123", {
-        tools: "[]",
+        requirements: "[]",
         sessionId: "session-456",
       });
 
@@ -434,7 +530,7 @@ describe("TeamsResource", () => {
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
       await resource.continue("team-1", "run-123", {
-        tools: "[]",
+        requirements: "[]",
         userId: "user-789",
       });
 
@@ -447,7 +543,9 @@ describe("TeamsResource", () => {
       const mockResponse = new Response("data: event", { status: 200 });
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
-      await resource.continue("team/special", "run/123", { tools: "[]" });
+      await resource.continue("team/special", "run/123", {
+        requirements: "[]",
+      });
 
       expect(requestStreamSpy).toHaveBeenCalledWith(
         "POST",

--- a/tests/resources/workflows.test.ts
+++ b/tests/resources/workflows.test.ts
@@ -611,28 +611,28 @@ describe("WorkflowsResource", () => {
   });
 
   describe("getRun()", () => {
-    it("calls GET /workflows/{workflowId}/runs/{runId}", async () => {
+    it("calls GET /workflows/{workflowId}/runs/{runId}?session_id=", async () => {
       const mockRun = { run_id: "run-1", status: "completed" };
       requestSpy.mockResolvedValueOnce(mockRun);
 
-      const result = await resource.getRun("workflow-1", "run-1");
+      const result = await resource.getRun("workflow-1", "run-1", "session-1");
 
       expect(result).toEqual(mockRun);
       expect(requestSpy).toHaveBeenCalledWith(
         "GET",
-        "/workflows/workflow-1/runs/run-1",
+        "/workflows/workflow-1/runs/run-1?session_id=session-1",
       );
       expect(requestSpy).toHaveBeenCalledTimes(1);
     });
 
-    it("URL-encodes workflowId and runId", async () => {
+    it("URL-encodes workflowId, runId and sessionId", async () => {
       requestSpy.mockResolvedValueOnce({});
 
-      await resource.getRun("workflow/special", "run/123");
+      await resource.getRun("workflow/special", "run/123", "session/xyz");
 
       expect(requestSpy).toHaveBeenCalledWith(
         "GET",
-        "/workflows/workflow%2Fspecial/runs/run%2F123",
+        "/workflows/workflow%2Fspecial/runs/run%2F123?session_id=session%2Fxyz",
       );
     });
 
@@ -640,7 +640,7 @@ describe("WorkflowsResource", () => {
       requestSpy.mockRejectedValueOnce(new Error("fail"));
 
       await expect(
-        resource.getRun("workflow-1", "run-1"),
+        resource.getRun("workflow-1", "run-1", "session-1"),
       ).rejects.toThrow("fail");
     });
   });


### PR DESCRIPTION
## Summary

Three hand-written SDK calls never matched their AgentOS routes (the routes are byte-identical in agno 2.8.5 and 3.0.0; the 3.0 audit surfaced them):

- `sessions.create()` sent `type` / `component_id` / `name` / `db_id` as a JSON body the route ignores. `POST /sessions` reads `type` and `db_id` from the **query** and a `CreateSessionRequest` body, so the call returned 200 and persisted an unnamed *agent* session with no component id (`ixora sessions create --type team` produced the wrong session).
- `sessions.rename()` posted `{ name }`; the route declares `session_name: str = Body(embed=True)` → 422.
- `workflows.getRun()` omitted the required `session_id` query → 422.
- `teams.continue()` posted HITL resolutions as the `tools` form field. Only the **agent** continue route reads `tools`; the team route reads `requirements: str = Form("")` and sweeps the unknown field into kwargs without erroring, so an approved tool was never marked resolved and the run re-paused on the same call (the endless `--bypass-confirmations` loop).

## Changes

`src/resources/sessions.ts`
- `create()`: `?type=&db_id=` in the query; body is `components["schemas"]["CreateSessionRequest"]` — `session_name`, `user_id`, and `componentId` mapped to `agent_id` / `team_id` / `workflow_id` by `type`.
- `CreateSessionOptions.type` narrowed from `string` to `SessionType = "agent" | "team" | "workflow"` (new export) — the only values the route accepts, and the SDK now needs it to choose the body field.
- `rename()`: body `{ session_name }` typed `components["schemas"]["Body_rename_session"]`.

`src/resources/workflows.ts`
- `getRun(workflowId, runId, sessionId)` — required positional `sessionId`, sent as `?session_id=`, matching `agents.getRun` / `teams.getRun`. **Breaking** signature change; recorded under `### Breaking` in the CHANGELOG.

`src/resources/teams.ts`
- `TeamContinueOptions` gains `requirements?: string` and `input?: string`; `tools` becomes optional and `@deprecated`.
- `continue()` sends `requirements` (and `input` when given). A legacy `tools` payload is wrapped as `[{ tool_execution: entry }, …]` and sent as `requirements`; `tools` is never posted to the team route. `requirements` wins when both are set; a non-array `tools` throws `TypeError` before any request.

Tests rewritten for the three shapes (`tests/resources/{sessions,workflows,teams}.test.ts`), CHANGELOG `[Unreleased]` gets `### Fixed` entries plus the two `### Breaking` lines, README session examples fixed (the old `create` example used option names that never existed).

Out of scope, filed separately: `workflows.continue()` has the same silent-drop bug against `step_requirements` → #20.

## `requirements` contract for callers

Callers (ixora-cli `chat/runner.ts`, `agentos-runs-command.ts`, `agentos/teams.ts`; carbon-ui `useAIStreamHandler.tsx`) should send, for team runs:

```ts
client.teams.continue(teamId, runId, {
  requirements: JSON.stringify(
    paused.requirements.map((r) => ({
      ...r,                                   // keep id, created_at, member_* as issued
      tool_execution: { ...r.tool_execution, confirmed: true /* or false */, confirmation_note },
    })),
  ),
  sessionId,
  input,        // optional follow-up user message (what `ixora teams continue <message>` should map to)
});
```

- One entry per RunPaused `requirements[]` item, resent as issued with the decision stamped on `tool_execution.confirmed` (`true` approve / `false` reject, optional `tool_execution.confirmation_note`). A requirement-level `confirmation: true|false` is equivalent — `RunRequirement.from_dict` lifts it onto `tool_execution.confirmed`.
- Keep `id` and `tool_execution.tool_call_id`: the server binds by `id` first, then by a unique `tool_call_id`. Every entry must carry a decision, otherwise the run pauses again.
- Payloads for user-input / external-execution pauses put `user_input_schema[].value` / `external_execution_result` on the same entry.
- The agent route is unchanged: `agents.continue()` still takes `tools` (`ToolExecution[]`).
- Until callers migrate, passing the confirmed `ToolExecution[]` as `tools` keeps working through the deprecated wrap (verified below).

## Verification

`npm test` (836 passed), `npm run typecheck`, `npm run lint`, `npm run build` — all green.

Live, against an isolated agno 3.0.0 ixora stack (`docker compose -p s2shapes …`, same image/`.env` as the shared `s2shared` stack, whose uvicorn worker had died under `--reload` — see note at the end) using a `tsx` script that imports the built `dist/` and logs every request the SDK makes:

**1. `sessions.create` / `rename` / `workflows.getRun`**

```
>>> POST /sessions?type=team
    json: {"team_id":"ibmi-team","session_name":"s2-shapes-1788535202320"}
<<< 201
create() -> { session_id: '0c42b95d-…', team_id: 'ibmi-team', session_name: 's2-shapes-1788535202320' }
GET /sessions/{id}?type=team -> { status: 200, session_name: 's2-shapes-1788535202320', agent_id: undefined, team_id: 'ibmi-team', workflow_id: undefined }
>>> POST /sessions/0c42b95d-…/rename
    json: {"session_name":"s2-shapes-1788535202320-renamed"}
<<< 200
rename() resolved (200); GET -> { …, session_name: 's2-shapes-1788535202320-renamed', team_id: 'ibmi-team' }
>>> GET /workflows/no-such-workflow/runs/no-such-run?session_id=no-such-session
<<< 404
workflows.getRun() -> NotFoundError - Workflow not found
```

**2. HITL: `teams.run` → paused → continue** (prompt asks `ibmi-team` to run `SELECT 1 FROM SYSIBM.SYSDUMMY1`, which gates on `validate_and_run_sql`)

```
>>> POST /teams/ibmi-team/runs   form: {"message":"Run exactly this SQL …","stream":"false","session_id":"0c42b95d-…"}
<<< 200
teams.run() -> { "status": "PAUSED", "requirements": [ { "id": "2daeb394-…", "tool_call_id": "toolu_01LV…", "tool_name": "validate_and_run_sql", "requires_confirmation": true, "confirmed": null } ] }

-- old wire shape (tools=...) via raw fetch --
POST tools= -> 200 { "status": "PAUSED", "requirements": [ { …, "confirmed": null } ],
  "content": "Team run paused. The following require input:\n- team: validate_and_run_sql requires confirmation" }

-- new SDK: teams.continue({ requirements }) --
>>> POST /teams/ibmi-team/runs/1d7fd524-…/continue
    form: {"requirements":"[{\"id\":\"2daeb394-…\",\"tool_execution\":{\"tool_call_id\":\"toolu_01LV…\",\"tool_name\":\"validate_and_run_sql\",\"tool_args\":{\"statement\":\"SELECT 1 FROM SYSIBM.SYSDUMMY1\"},…,\"confirmed\":true…","stream":"false","session_id":"0c42b95d-…"}
<<< 200
teams.continue() -> { "status": "COMPLETED", "requirements": [ { …, "requires_confirmation": false, "confirmed": true } ],
  "content": "The query returned **1**.\n\nOne row was produced …" }

cleanup: DELETE /sessions/0c42b95d-…?type=team -> 204
```

Same run, old shape → still `PAUSED` with `confirmed: null`; new shape → `COMPLETED` with the tool result.

**3. Deprecated `tools` path** (same prompt; `teams.continue({ tools: ToolExecution[] })` — the SDK wraps each entry as `{ tool_execution }`, no `id`, and the server binds by `tool_call_id`)

```
teams.run() -> { "status": "PAUSED", "requirements": [ { "id": "739a320b-…", "tool_call_id": "toolu_01Qa…", "tool_name": "validate_and_run_sql", "requires_confirmation": true, "confirmed": null } ] }

-- new SDK, deprecated path: teams.continue({ tools }) wrapped as requirements --
>>> POST /teams/ibmi-team/runs/8621249e-…/continue
    form: {"requirements":"[{\"tool_execution\":{\"tool_call_id\":\"toolu_01Qa…\",\"tool_name\":\"validate_and_run_sql\",\"tool_args\":{\"statement\":\"SELECT 1 FROM SYSIBM.SYSDUMMY1\"},…,\"confirmed\":true,…","stream":"false","session_id":"adeb43e3-…"}
<<< 200
teams.continue() -> { "status": "COMPLETED", "requirements": [ { "id": "739a320b-…", …, "requires_confirmation": false, "confirmed": true } ],
  "content": "The query returned **1**.\n\nOne row was returned with the column value `1`, …" }

cleanup: DELETE /sessions/adeb43e3-…?type=team -> 204
```

Note on the shared `s2shared` stack (:8050): while this was being verified its `agentos-api` container stopped answering — the uvicorn `--reload` master (pid 1) still holds :8000 with ~47 queued connections but the app worker is a zombie, so every request times out. It was not restarted from here; it needs a `docker compose -p s2shared … restart agentos-api` from whoever owns it.

Closes #10
Part of #11 — this PR is the SDK half; the ixora-cli half (ibmi-agi/ixora-cli#139) closes it, and the carbon-ui half is ibmi-agi/ixora#252.

