### PR TITLE
feat(errors): surface error_id/error_type on APIError and return typed migrate results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,19 @@ This project follows [Semantic Versioning](https://semver.org/).
 - `AgentOSClient.getConfig()` returns `components["schemas"]["ConfigResponse"]`
   instead of the hand-written `OSConfig`, so `available_models` typechecks as
   `Model[]`.
+- `database.migrate()` / `database.migrateAll()` return `Promise<MigrateResult>`
+  instead of `Promise<void>`, and `migrateAll()` throws `MigrationFailedError`
+  on a 207 Multi-Status instead of resolving as success. A 207 satisfies
+  `response.ok`, so a failed migration — which a stack that registers every
+  database under one id always reports as 207, never 5xx — was previously
+  reported to the caller as a clean success.
+- Streaming requests (`agents.runStream()`, `teams.runStream()`, ...) parse a
+  non-2xx body the same way non-streaming ones do: `message` is the JSON
+  `detail` (or `message` / `error`) rather than the raw body text, and
+  `errorId` / `errorType` are populated.
+- Error bodies are read once as text and then parsed. Previously a non-JSON
+  error body surfaced as `HTTP <status>`: the `text()` fallback ran after a
+  failed `json()` had already consumed the stream.
 
 ### Breaking
 
@@ -73,6 +86,21 @@ Release note: this warrants a minor bump (0.7.0), not a patch.
 ### Added
 
 - `GetMetricsOptions.userId`, sent as the `user_id` query param on `GET /metrics`.
+- `APIError.errorId` / `APIError.errorType`: the `error_id` / `error_type` that
+  agno >= 3.0 puts in typed error bodies (`migration_required_error`,
+  `schema_mismatch_error`, ...), so callers can branch on identity instead of
+  `message` text. Both are optional — a plain `{ detail }` body leaves them
+  `undefined`. Every error class accepts them through a trailing `options`
+  argument (`APIErrorOptions`, exported) and `createErrorFromResponse` threads
+  them through, on both the `request()` and `requestStream()` paths.
+- `ConflictError` (409). agno 3.0 answers 409 for a reused idempotency key and
+  for continuing a run that is not paused. Not retried by `requestWithRetry`.
+- `MigrateResult` (`{ message, failed?, skipped? }`): the body of
+  `POST /databases/{db_id}/migrate` and `POST /databases/all/migrate`.
+- `MigrationFailedError` (status 207), thrown by `database.migrateAll()` when
+  the server answers 207 Multi-Status with a non-empty `failed` map (database
+  id -> failure reason); `skipped` lists the remote databases the server left
+  alone.
 
 
 ## [0.6.1] - 2026-06-05

--- a/README.md
+++ b/README.md
@@ -509,8 +509,9 @@ All API errors extend `APIError` and include:
 - `headers`: Response headers
 - `errorId`: Stable error identifier from the response body (agno >= 3.0), e.g.
   `"migration_required_error"`; `undefined` when the body carries none
-- `errorType`: Server-side error class name (agno >= 3.0), e.g.
-  `"MigrationRequiredError"`; `undefined` when the body carries none
+- `errorType`: Server-side error type (agno >= 3.0). agno currently sets it to
+  the same snake_case value as `error_id`, so branch on `errorId` and treat this
+  as informational; `undefined` when the body carries none
 
 Streaming and non-streaming requests parse error bodies the same way.
 

--- a/README.md
+++ b/README.md
@@ -466,9 +466,11 @@ import {
   APIError,
   AuthenticationError,
   BadRequestError,
+  ConflictError,
   NotFoundError,
   RateLimitError,
   InternalServerError,
+  MigrationFailedError,
   RemoteServerUnavailableError,
   UnprocessableEntityError
 } from '@worksofadam/agentos-sdk';
@@ -504,7 +506,50 @@ All API errors extend `APIError` and include:
 - `status`: HTTP status code
 - `message`: Error message from API
 - `requestId`: X-Request-ID header value (for support)
-- `body`: Raw response body
+- `headers`: Response headers
+- `errorId`: Stable error identifier from the response body (agno >= 3.0), e.g.
+  `"migration_required_error"`; `undefined` when the body carries none
+- `errorType`: Server-side error class name (agno >= 3.0), e.g.
+  `"MigrationRequiredError"`; `undefined` when the body carries none
+
+Streaming and non-streaming requests parse error bodies the same way.
+
+### Branching on `errorId`
+
+agno 3.0 stamps typed failures with a machine-readable identity, so you can
+branch on `errorId` instead of matching `message` text:
+
+```typescript
+try {
+  await client.agents.run('agent-id', { message: 'Hello!' });
+} catch (error) {
+  if (error instanceof APIError && error.errorId === 'migration_required_error') {
+    await client.database.migrateAll();
+  } else {
+    throw error;
+  }
+}
+```
+
+### Migration results
+
+`client.database.migrate()` and `client.database.migrateAll()` return the
+server's `MigrateResult` (`{ message, failed?, skipped? }`). `migrateAll()`
+throws `MigrationFailedError` when the server answers 207 Multi-Status because
+at least one database failed; `failed` maps each database id to its reason:
+
+```typescript
+try {
+  const { message, skipped } = await client.database.migrateAll();
+  console.log(message, skipped ?? []);
+} catch (error) {
+  if (error instanceof MigrationFailedError) {
+    for (const [dbId, reason] of Object.entries(error.failed)) {
+      console.error(`${dbId}: ${reason}`);
+    }
+  }
+}
+```
 
 ## TypeScript
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { createErrorFromResponse } from "./errors";
 import type { components } from "./generated/types";
-import { requestWithRetry } from "./http";
+import { parseErrorBody, requestWithRetry } from "./http";
 import { VERSION } from "./index";
 import { AgentsResource } from "./resources/agents";
 import { ApprovalsResource } from "./resources/approvals";
@@ -182,13 +182,14 @@ export class AgentOSClient {
     const response = await fetch(url, fetchOptions);
 
     if (!response.ok) {
-      const message = await response.text();
+      const { message, errorId, errorType } = await parseErrorBody(response);
       const requestId = response.headers.get("x-request-id") ?? undefined;
       throw createErrorFromResponse(
         response.status,
         message,
         requestId,
         this.extractHeaders(response.headers),
+        { errorId, errorType },
       );
     }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,7 +9,11 @@
 export interface APIErrorOptions {
   /** Stable error identifier, e.g. `"migration_required_error"` */
   errorId?: string;
-  /** Error class name on the server, e.g. `"MigrationRequiredError"` */
+  /**
+   * Server-side error type. agno currently sets it to the same snake_case
+   * value as `error_id` (e.g. `"migration_required_error"`); branch on
+   * `errorId` and treat this as informational.
+   */
   errorType?: string;
 }
 
@@ -39,7 +43,7 @@ export class APIError extends Error {
   readonly headers?: Record<string, string>;
   /** Stable error identifier from the response body (agno >= 3.0), if any */
   readonly errorId?: string;
-  /** Server-side error type from the response body (agno >= 3.0), if any */
+  /** Server-side error type from the response body (agno >= 3.0), if any; see `APIErrorOptions` */
   readonly errorType?: string;
 
   constructor(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,19 @@
 /**
+ * Machine-readable error identity carried by agno >= 3.0 error bodies.
+ *
+ * agno 3.0 emits `{ detail, error_id, error_type }` for typed failures
+ * (`AgnoError` / `AgnoHTTPException`, e.g. `migration_required_error`).
+ * Plain `HTTPException` bodies and older servers emit `{ detail }` only,
+ * so both fields are optional.
+ */
+export interface APIErrorOptions {
+  /** Stable error identifier, e.g. `"migration_required_error"` */
+  errorId?: string;
+  /** Error class name on the server, e.g. `"MigrationRequiredError"` */
+  errorType?: string;
+}
+
+/**
  * Base API error class for all AgentOS SDK errors.
  *
  * Use `instanceof` to catch specific error types:
@@ -22,12 +37,17 @@ export class APIError extends Error {
   readonly message: string;
   readonly requestId?: string;
   readonly headers?: Record<string, string>;
+  /** Stable error identifier from the response body (agno >= 3.0), if any */
+  readonly errorId?: string;
+  /** Server-side error type from the response body (agno >= 3.0), if any */
+  readonly errorType?: string;
 
   constructor(
     status: number,
     message: string,
     requestId?: string,
     headers?: Record<string, string>,
+    options?: APIErrorOptions,
   ) {
     super(message);
     this.name = "APIError";
@@ -35,6 +55,8 @@ export class APIError extends Error {
     this.message = message;
     this.requestId = requestId;
     this.headers = headers;
+    this.errorId = options?.errorId;
+    this.errorType = options?.errorType;
     // Critical for instanceof to work with ES5 compilation
     Object.setPrototypeOf(this, APIError.prototype);
   }
@@ -49,8 +71,9 @@ export class BadRequestError extends APIError {
     message: string,
     requestId?: string,
     headers?: Record<string, string>,
+    options?: APIErrorOptions,
   ) {
-    super(400, message, requestId, headers);
+    super(400, message, requestId, headers, options);
     this.name = "BadRequestError";
     Object.setPrototypeOf(this, BadRequestError.prototype);
   }
@@ -65,8 +88,9 @@ export class AuthenticationError extends APIError {
     message: string,
     requestId?: string,
     headers?: Record<string, string>,
+    options?: APIErrorOptions,
   ) {
-    super(401, message, requestId, headers);
+    super(401, message, requestId, headers, options);
     this.name = "AuthenticationError";
     Object.setPrototypeOf(this, AuthenticationError.prototype);
   }
@@ -81,10 +105,29 @@ export class NotFoundError extends APIError {
     message: string,
     requestId?: string,
     headers?: Record<string, string>,
+    options?: APIErrorOptions,
   ) {
-    super(404, message, requestId, headers);
+    super(404, message, requestId, headers, options);
     this.name = "NotFoundError";
     Object.setPrototypeOf(this, NotFoundError.prototype);
+  }
+}
+
+/**
+ * Thrown when the request conflicts with the current server state
+ * (e.g. a reused idempotency key, or continuing a run that is not paused).
+ * HTTP status code: 409
+ */
+export class ConflictError extends APIError {
+  constructor(
+    message: string,
+    requestId?: string,
+    headers?: Record<string, string>,
+    options?: APIErrorOptions,
+  ) {
+    super(409, message, requestId, headers, options);
+    this.name = "ConflictError";
+    Object.setPrototypeOf(this, ConflictError.prototype);
   }
 }
 
@@ -97,8 +140,9 @@ export class UnprocessableEntityError extends APIError {
     message: string,
     requestId?: string,
     headers?: Record<string, string>,
+    options?: APIErrorOptions,
   ) {
-    super(422, message, requestId, headers);
+    super(422, message, requestId, headers, options);
     this.name = "UnprocessableEntityError";
     Object.setPrototypeOf(this, UnprocessableEntityError.prototype);
   }
@@ -113,8 +157,9 @@ export class RateLimitError extends APIError {
     message: string,
     requestId?: string,
     headers?: Record<string, string>,
+    options?: APIErrorOptions,
   ) {
-    super(429, message, requestId, headers);
+    super(429, message, requestId, headers, options);
     this.name = "RateLimitError";
     Object.setPrototypeOf(this, RateLimitError.prototype);
   }
@@ -129,8 +174,9 @@ export class InternalServerError extends APIError {
     message: string,
     requestId?: string,
     headers?: Record<string, string>,
+    options?: APIErrorOptions,
   ) {
-    super(500, message, requestId, headers);
+    super(500, message, requestId, headers, options);
     this.name = "InternalServerError";
     Object.setPrototypeOf(this, InternalServerError.prototype);
   }
@@ -145,10 +191,50 @@ export class RemoteServerUnavailableError extends APIError {
     message: string,
     requestId?: string,
     headers?: Record<string, string>,
+    options?: APIErrorOptions,
   ) {
-    super(503, message, requestId, headers);
+    super(503, message, requestId, headers, options);
     this.name = "RemoteServerUnavailableError";
     Object.setPrototypeOf(this, RemoteServerUnavailableError.prototype);
+  }
+}
+
+/**
+ * Thrown by `client.database.migrateAll()` when the server answers
+ * 207 Multi-Status: at least one database failed to migrate. The route
+ * migrates every database it can and reports the failures per database
+ * id instead of failing the whole request, so a 207 satisfies `response.ok`
+ * and is surfaced as this error from the parsed body rather than by status.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await client.database.migrateAll();
+ * } catch (error) {
+ *   if (error instanceof MigrationFailedError) {
+ *     for (const [dbId, reason] of Object.entries(error.failed)) {
+ *       console.error(`${dbId}: ${reason}`);
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export class MigrationFailedError extends APIError {
+  /** Database id -> failure reason, for every database that failed */
+  readonly failed: Record<string, string>;
+  /** Remote database ids the server skipped (migrate them on their own AgentOS) */
+  readonly skipped?: string[];
+
+  constructor(
+    message: string,
+    failed: Record<string, string>,
+    skipped?: string[],
+  ) {
+    super(207, message);
+    this.name = "MigrationFailedError";
+    this.failed = failed;
+    this.skipped = skipped;
+    Object.setPrototypeOf(this, MigrationFailedError.prototype);
   }
 }
 
@@ -159,6 +245,7 @@ export class RemoteServerUnavailableError extends APIError {
  * @param message - Error message
  * @param requestId - Optional request ID from response headers
  * @param headers - Optional response headers
+ * @param options - Optional `error_id` / `error_type` from the response body
  * @returns The appropriate APIError subclass instance
  */
 export function createErrorFromResponse(
@@ -166,28 +253,36 @@ export function createErrorFromResponse(
   message: string,
   requestId?: string,
   headers?: Record<string, string>,
+  options?: APIErrorOptions,
 ): APIError {
   switch (status) {
     case 400:
-      return new BadRequestError(message, requestId, headers);
+      return new BadRequestError(message, requestId, headers, options);
     case 401:
-      return new AuthenticationError(message, requestId, headers);
+      return new AuthenticationError(message, requestId, headers, options);
     case 404:
-      return new NotFoundError(message, requestId, headers);
+      return new NotFoundError(message, requestId, headers, options);
+    case 409:
+      return new ConflictError(message, requestId, headers, options);
     case 422:
-      return new UnprocessableEntityError(message, requestId, headers);
+      return new UnprocessableEntityError(message, requestId, headers, options);
     case 429:
-      return new RateLimitError(message, requestId, headers);
+      return new RateLimitError(message, requestId, headers, options);
     case 500:
-      return new InternalServerError(message, requestId, headers);
+      return new InternalServerError(message, requestId, headers, options);
     case 503:
-      return new RemoteServerUnavailableError(message, requestId, headers);
+      return new RemoteServerUnavailableError(
+        message,
+        requestId,
+        headers,
+        options,
+      );
     default:
       // For other 5xx errors, use InternalServerError
       if (status >= 500) {
-        return new InternalServerError(message, requestId, headers);
+        return new InternalServerError(message, requestId, headers, options);
       }
       // For unrecognized status codes, use generic APIError
-      return new APIError(status, message, requestId, headers);
+      return new APIError(status, message, requestId, headers, options);
   }
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -10,46 +10,86 @@ function isObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Parse error body from a failed response.
- * Attempts to extract a message from common JSON formats,
- * falling back to text or statusText.
+ * The parts of a failed response body the SDK surfaces on `APIError`.
  */
-async function parseErrorBody(response: Response): Promise<string> {
-  try {
-    const json: unknown = await response.json();
+export interface ParsedErrorBody {
+  /** Human-readable message (from `message`, `error`, `error.message` or `detail`) */
+  message: string;
+  /** agno >= 3.0 `error_id`, when the body carries one */
+  errorId?: string;
+  /** agno >= 3.0 `error_type`, when the body carries one */
+  errorType?: string;
+}
 
-    // Try common message formats
-    if (isObject(json)) {
-      if (typeof json.message === "string") {
-        return json.message;
-      }
-      if (typeof json.error === "string") {
-        return json.error;
-      }
-      if (isObject(json.error) && typeof json.error.message === "string") {
-        return json.error.message;
-      }
-      if (typeof json.detail === "string") {
-        return json.detail;
-      }
-    }
-
-    // Return stringified JSON if no message field found
-    return JSON.stringify(json);
-  } catch {
-    // JSON parsing failed, try text
-    try {
-      const text = await response.text();
-      if (text) {
-        return text;
-      }
-    } catch {
-      // Text parsing also failed
-    }
-
-    // Fall back to statusText
-    return response.statusText || `HTTP ${response.status}`;
+/**
+ * Extract a message from common JSON error formats.
+ */
+function extractMessage(json: Record<string, unknown>): string | undefined {
+  if (typeof json.message === "string") {
+    return json.message;
   }
+  if (typeof json.error === "string") {
+    return json.error;
+  }
+  if (isObject(json.error) && typeof json.error.message === "string") {
+    return json.error.message;
+  }
+  if (typeof json.detail === "string") {
+    return json.detail;
+  }
+  return undefined;
+}
+
+/**
+ * Parse error body from a failed response.
+ *
+ * Attempts to extract a message from common JSON formats, falling back to
+ * the raw text or statusText. When the body is an agno >= 3.0 error body
+ * (`{ detail, error_id, error_type }`) the identity fields are returned too,
+ * so callers can branch on `errorId` instead of matching `message` text.
+ *
+ * The body is read once as text and then parsed: a failed `response.json()`
+ * has already consumed the stream, so a `text()` fallback after it throws
+ * "Body is unusable" and non-JSON bodies would surface as `HTTP <status>`.
+ */
+export async function parseErrorBody(
+  response: Response,
+): Promise<ParsedErrorBody> {
+  let text: string;
+  try {
+    text = await response.text();
+  } catch {
+    text = "";
+  }
+
+  if (!text) {
+    // Empty or unreadable body: fall back to statusText
+    return { message: response.statusText || `HTTP ${response.status}` };
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    // Not JSON: the raw text is the message
+    return { message: text };
+  }
+
+  if (isObject(json)) {
+    const result: ParsedErrorBody = {
+      // Return stringified JSON if no message field found
+      message: extractMessage(json) ?? text,
+    };
+    if (typeof json.error_id === "string") {
+      result.errorId = json.error_id;
+    }
+    if (typeof json.error_type === "string") {
+      result.errorType = json.error_type;
+    }
+    return result;
+  }
+
+  return { message: text };
 }
 
 /**
@@ -113,12 +153,13 @@ export async function request<T>(
   const responseHeaders = extractHeaders(response.headers);
 
   if (!response.ok) {
-    const message = await parseErrorBody(response);
+    const { message, errorId, errorType } = await parseErrorBody(response);
     throw createErrorFromResponse(
       response.status,
       message,
       requestId,
       responseHeaders,
+      { errorId, errorType },
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export type {
 } from "./resources/components";
 
 export { DatabaseResource } from "./resources/database";
-export type { MigrateOptions } from "./resources/database";
+export type { MigrateOptions, MigrateResult } from "./resources/database";
 
 export { EvalsResource } from "./resources/evals";
 export type {
@@ -138,12 +138,15 @@ export {
   APIError,
   AuthenticationError,
   BadRequestError,
+  ConflictError,
   InternalServerError,
+  MigrationFailedError,
   NotFoundError,
   RateLimitError,
   RemoteServerUnavailableError,
   UnprocessableEntityError,
 } from "./errors";
+export type { APIErrorOptions } from "./errors";
 
 // Streaming
 export {

--- a/src/resources/database.ts
+++ b/src/resources/database.ts
@@ -1,4 +1,5 @@
 import type { AgentOSClient } from "../client";
+import { MigrationFailedError } from "../errors";
 
 /**
  * Options for database migration with optional target version
@@ -6,6 +7,23 @@ import type { AgentOSClient } from "../client";
 export interface MigrateOptions {
   /** Target migration version */
   targetVersion?: string;
+}
+
+/**
+ * Outcome of a database migration.
+ *
+ * `POST /databases/{db_id}/migrate` answers 200 `{ message }`.
+ * `POST /databases/all/migrate` answers 200 `{ message, skipped? }`, or
+ * 207 Multi-Status `{ message, failed, skipped? }` when at least one
+ * database failed - `migrateAll()` turns that into a `MigrationFailedError`.
+ */
+export interface MigrateResult {
+  /** Human-readable summary, e.g. "All databases migrated successfully to latest version" */
+  message: string;
+  /** Database id -> failure reason; present only on a 207 Multi-Status */
+  failed?: Record<string, string>;
+  /** Remote database ids the server skipped (they migrate on their own AgentOS) */
+  skipped?: string[];
 }
 
 /**
@@ -19,15 +37,15 @@ export interface MigrateOptions {
  * const client = new AgentOSClient({ baseUrl: '...' });
  *
  * // Migrate a specific database
- * await client.databases.migrate('my-database');
+ * await client.database.migrate('my-database');
  *
  * // Migrate to a specific version
- * await client.databases.migrate('my-database', {
+ * await client.database.migrate('my-database', {
  *   targetVersion: '3',
  * });
  *
  * // Migrate all databases
- * await client.databases.migrateAll();
+ * await client.database.migrateAll();
  * ```
  */
 export class DatabaseResource {
@@ -38,20 +56,23 @@ export class DatabaseResource {
    *
    * @param dbId - The unique identifier for the database
    * @param options - Migration options including optional target version
-   * @returns Resolves when the migration completes
+   * @returns The server's migration summary
    *
    * @example
    * ```typescript
    * // Migrate to latest version
-   * await client.databases.migrate('my-database');
+   * const { message } = await client.database.migrate('my-database');
    *
    * // Migrate to a specific version
-   * await client.databases.migrate('my-database', {
+   * await client.database.migrate('my-database', {
    *   targetVersion: '5',
    * });
    * ```
    */
-  async migrate(dbId: string, options?: MigrateOptions): Promise<void> {
+  async migrate(
+    dbId: string,
+    options?: MigrateOptions,
+  ): Promise<MigrateResult> {
     const params = new URLSearchParams();
 
     if (options?.targetVersion) {
@@ -63,25 +84,28 @@ export class DatabaseResource {
       ? `/databases/${encodeURIComponent(dbId)}/migrate?${queryString}`
       : `/databases/${encodeURIComponent(dbId)}/migrate`;
 
-    await this.client.request<void>("POST", path);
+    return this.client.request<MigrateResult>("POST", path);
   }
 
   /**
    * Migrate all databases
    *
    * @param options - Migration options including optional target version
-   * @returns Resolves when all migrations complete
+   * @returns The server's migration summary, including any `skipped` remote databases
+   * @throws {MigrationFailedError} When the server answers 207 Multi-Status
+   *   because at least one database failed to migrate; `failed` maps each
+   *   database id to its failure reason.
    *
    * @example
    * ```typescript
    * // Migrate all databases to latest
-   * await client.databases.migrateAll();
+   * await client.database.migrateAll();
    *
    * // Migrate all databases to a specific version
-   * await client.databases.migrateAll({ targetVersion: '3' });
+   * await client.database.migrateAll({ targetVersion: '3' });
    * ```
    */
-  async migrateAll(options?: MigrateOptions): Promise<void> {
+  async migrateAll(options?: MigrateOptions): Promise<MigrateResult> {
     const params = new URLSearchParams();
 
     if (options?.targetVersion) {
@@ -93,6 +117,18 @@ export class DatabaseResource {
       ? `/databases/all/migrate?${queryString}`
       : "/databases/all/migrate";
 
-    await this.client.request<void>("POST", path);
+    const result = await this.client.request<MigrateResult>("POST", path);
+
+    // A 207 Multi-Status satisfies `response.ok`, so the transport never
+    // throws for it; the non-empty `failed` map is the only signal.
+    if (result.failed && Object.keys(result.failed).length > 0) {
+      throw new MigrationFailedError(
+        result.message,
+        result.failed,
+        result.skipped,
+      );
+    }
+
+    return result;
   }
 }

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentOSClient } from "../src/client";
-import { AuthenticationError } from "../src/errors";
+import { AuthenticationError, InternalServerError } from "../src/errors";
 import { VERSION } from "../src/index";
 
-// Mock the http module
-vi.mock("../src/http", () => ({
-  requestWithRetry: vi.fn(),
-}));
+// Mock the http module (keep the real parseErrorBody so requestStream's
+// error path is exercised end-to-end)
+vi.mock("../src/http", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/http")>();
+  return { ...actual, requestWithRetry: vi.fn() };
+});
 
 import { requestWithRetry } from "../src/http";
 
@@ -682,6 +684,46 @@ describe("AgentOSClient", () => {
       const promise = (client as any).requestStream("POST", "/stream");
 
       await expect(promise).rejects.toThrow(AuthenticationError);
+    });
+
+    it("should parse a JSON error body and surface error_id / error_type", async () => {
+      const mockFetch = vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              detail: "Database schema is out of date",
+              error_id: "migration_required_error",
+              error_type: "MigrationRequiredError",
+            }),
+            {
+              status: 500,
+              headers: {
+                "content-type": "application/json",
+                "x-request-id": "req-500",
+              },
+            },
+          ),
+        ),
+      );
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const client = new AgentOSClient({
+        baseUrl: "https://api.example.com",
+      });
+
+      // biome-ignore lint/suspicious/noExplicitAny: Need to access internal method for testing
+      const promise = (client as any).requestStream("POST", "/stream");
+
+      await expect(promise).rejects.toThrow(InternalServerError);
+      await expect(promise).rejects.toMatchObject({
+        status: 500,
+        // The message is the parsed `detail`, not the raw JSON text
+        message: "Database schema is out of date",
+        errorId: "migration_required_error",
+        errorType: "MigrationRequiredError",
+        requestId: "req-500",
+      });
     });
 
     it("should include Authorization header when apiKey is set", async () => {

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -3,7 +3,9 @@ import {
   APIError,
   AuthenticationError,
   BadRequestError,
+  ConflictError,
   InternalServerError,
+  MigrationFailedError,
   NotFoundError,
   RateLimitError,
   RemoteServerUnavailableError,
@@ -19,6 +21,21 @@ describe("Error Classes", () => {
       expect(error.message).toBe("Server error");
       expect(error.requestId).toBe("req-123");
       expect(error.name).toBe("APIError");
+    });
+
+    it("carries errorId and errorType from the options arg", () => {
+      const error = new APIError(500, "Server error", undefined, undefined, {
+        errorId: "migration_required_error",
+        errorType: "MigrationRequiredError",
+      });
+      expect(error.errorId).toBe("migration_required_error");
+      expect(error.errorType).toBe("MigrationRequiredError");
+    });
+
+    it("has undefined errorId and errorType when options are omitted", () => {
+      const error = new APIError(500, "Server error");
+      expect(error.errorId).toBeUndefined();
+      expect(error.errorType).toBeUndefined();
     });
 
     it("should work with instanceof", () => {
@@ -101,6 +118,60 @@ describe("Error Classes", () => {
     it("should preserve requestId and headers", () => {
       const error = new NotFoundError("Resource not found", "req-003");
       expect(error.requestId).toBe("req-003");
+    });
+  });
+
+  describe("ConflictError", () => {
+    it("should have status 409", () => {
+      const error = new ConflictError("Run is not paused");
+      expect(error.status).toBe(409);
+      expect(error.name).toBe("ConflictError");
+    });
+
+    it("should work with instanceof", () => {
+      const error = new ConflictError("Run is not paused");
+      expect(error instanceof ConflictError).toBe(true);
+      expect(error instanceof APIError).toBe(true);
+      expect(error instanceof Error).toBe(true);
+    });
+
+    it("should preserve requestId, headers and options", () => {
+      const headers = { "content-type": "application/json" };
+      const error = new ConflictError("Conflict", "req-409", headers, {
+        errorId: "conflict_error",
+      });
+      expect(error.requestId).toBe("req-409");
+      expect(error.headers).toEqual(headers);
+      expect(error.errorId).toBe("conflict_error");
+    });
+  });
+
+  describe("MigrationFailedError", () => {
+    const failed = { "agentos-db": "relation already exists" };
+
+    it("should have status 207 and carry failed / skipped", () => {
+      const error = new MigrationFailedError(
+        "Migrated 0/1 databases to latest version",
+        failed,
+        ["remote-db"],
+      );
+      expect(error.status).toBe(207);
+      expect(error.name).toBe("MigrationFailedError");
+      expect(error.message).toBe("Migrated 0/1 databases to latest version");
+      expect(error.failed).toEqual(failed);
+      expect(error.skipped).toEqual(["remote-db"]);
+    });
+
+    it("leaves skipped undefined when not provided", () => {
+      const error = new MigrationFailedError("Migrated 0/1", failed);
+      expect(error.skipped).toBeUndefined();
+    });
+
+    it("should work with instanceof", () => {
+      const error = new MigrationFailedError("Migrated 0/1", failed);
+      expect(error instanceof MigrationFailedError).toBe(true);
+      expect(error instanceof APIError).toBe(true);
+      expect(error instanceof Error).toBe(true);
     });
   });
 
@@ -215,6 +286,12 @@ describe("Error Classes", () => {
       expect(error.status).toBe(404);
     });
 
+    it("should create ConflictError for 409", () => {
+      const error = createErrorFromResponse(409, "Conflict");
+      expect(error instanceof ConflictError).toBe(true);
+      expect(error.status).toBe(409);
+    });
+
     it("should create UnprocessableEntityError for 422", () => {
       const error = createErrorFromResponse(422, "Validation error");
       expect(error instanceof UnprocessableEntityError).toBe(true);
@@ -274,6 +351,24 @@ describe("Error Classes", () => {
       expect(error.requestId).toBe("req-test");
       expect(error.headers).toEqual(headers);
     });
+
+    it("threads errorId / errorType through to every class", () => {
+      const options = {
+        errorId: "migration_required_error",
+        errorType: "MigrationRequiredError",
+      };
+      for (const status of [400, 401, 404, 409, 422, 429, 500, 502, 503, 418]) {
+        const error = createErrorFromResponse(
+          status,
+          "msg",
+          undefined,
+          undefined,
+          options,
+        );
+        expect(error.errorId).toBe("migration_required_error");
+        expect(error.errorType).toBe("MigrationRequiredError");
+      }
+    });
   });
 
   describe("Error inheritance chain", () => {
@@ -282,10 +377,12 @@ describe("Error Classes", () => {
         new BadRequestError("test"),
         new AuthenticationError("test"),
         new NotFoundError("test"),
+        new ConflictError("test"),
         new UnprocessableEntityError("test"),
         new RateLimitError("test"),
         new InternalServerError("test"),
         new RemoteServerUnavailableError("test"),
+        new MigrationFailedError("test", { db: "reason" }),
       ];
 
       for (const error of errors) {

--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -2,19 +2,89 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   APIError,
   BadRequestError,
+  ConflictError,
   InternalServerError,
   NotFoundError,
   RateLimitError,
 } from "../src/errors";
-import { request, requestWithRetry } from "../src/http";
+import { parseErrorBody, request, requestWithRetry } from "../src/http";
 
 // Mock global fetch
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+/**
+ * Build a real Response for the error path. parseErrorBody consumes the body
+ * exactly once, so mocks that only stub `json()` would not exercise it.
+ */
+function errorResponse(
+  status: number,
+  body: unknown,
+  init: { headers?: Record<string, string>; statusText?: string } = {},
+): Response {
+  return new Response(
+    typeof body === "string" ? body : JSON.stringify(body),
+    { status, ...init },
+  );
+}
+
 describe("HTTP Module", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+  });
+
+  describe("parseErrorBody", () => {
+    it("returns error_id and error_type from an agno 3.0 error body", async () => {
+      const response = errorResponse(500, {
+        detail: "Database schema is out of date",
+        error_id: "migration_required_error",
+        error_type: "MigrationRequiredError",
+      });
+
+      await expect(parseErrorBody(response)).resolves.toEqual({
+        message: "Database schema is out of date",
+        errorId: "migration_required_error",
+        errorType: "MigrationRequiredError",
+      });
+    });
+
+    it("leaves errorId and errorType undefined for a plain {detail} body", async () => {
+      const parsed = await parseErrorBody(
+        errorResponse(404, { detail: "Not found" }),
+      );
+      expect(parsed).toEqual({ message: "Not found" });
+      expect(parsed.errorId).toBeUndefined();
+      expect(parsed.errorType).toBeUndefined();
+    });
+
+    it("ignores non-string error_id / error_type", async () => {
+      await expect(
+        parseErrorBody(
+          errorResponse(500, { detail: "x", error_id: 42, error_type: null }),
+        ),
+      ).resolves.toEqual({ message: "x" });
+    });
+
+    it("uses the raw text when the body is not JSON", async () => {
+      await expect(
+        parseErrorBody(errorResponse(500, "Internal Server Error")),
+      ).resolves.toEqual({ message: "Internal Server Error" });
+    });
+
+    it("stringifies a JSON body without a recognised message field", async () => {
+      await expect(
+        parseErrorBody(errorResponse(500, { foo: "bar" })),
+      ).resolves.toEqual({ message: '{"foo":"bar"}' });
+    });
+
+    it("falls back to statusText, then HTTP <status>, for an empty body", async () => {
+      await expect(
+        parseErrorBody(errorResponse(502, "", { statusText: "Bad Gateway" })),
+      ).resolves.toEqual({ message: "Bad Gateway" });
+      await expect(parseErrorBody(errorResponse(502, ""))).resolves.toEqual({
+        message: "HTTP 502",
+      });
+    });
   });
 
   describe("request", () => {
@@ -44,12 +114,13 @@ describe("HTTP Module", () => {
     });
 
     it("should throw BadRequestError for 400", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        json: () => Promise.resolve({ message: "Invalid input" }),
-        headers: new Headers({ "x-request-id": "req-123" }),
-      });
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(
+          400,
+          { message: "Invalid input" },
+          { headers: { "x-request-id": "req-123" } },
+        ),
+      );
 
       await expect(request("https://api.test.com/endpoint")).rejects.toThrow(
         BadRequestError,
@@ -57,12 +128,9 @@ describe("HTTP Module", () => {
     });
 
     it("should throw NotFoundError for 404", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        json: () => Promise.resolve({ message: "Not found" }),
-        headers: new Headers(),
-      });
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(404, { message: "Not found" }),
+      );
 
       await expect(request("https://api.test.com/endpoint")).rejects.toThrow(
         NotFoundError,
@@ -70,83 +138,119 @@ describe("HTTP Module", () => {
     });
 
     it("should include requestId in error", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: () => Promise.resolve({ message: "Server error" }),
-        headers: new Headers({ "x-request-id": "req-456" }),
-      });
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(
+          500,
+          { message: "Server error" },
+          { headers: { "x-request-id": "req-456" } },
+        ),
+      );
 
-      try {
-        await request("https://api.test.com/endpoint");
-      } catch (error) {
-        expect(error).toBeInstanceOf(InternalServerError);
-        expect((error as APIError).requestId).toBe("req-456");
-      }
+      await expect(
+        request("https://api.test.com/endpoint"),
+      ).rejects.toMatchObject({
+        name: "InternalServerError",
+        requestId: "req-456",
+      });
     });
 
     it("should handle non-JSON error responses", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: () => Promise.reject(new Error("Not JSON")),
-        text: () => Promise.resolve("Internal Server Error"),
-        statusText: "Internal Server Error",
-        headers: new Headers(),
-      });
-
-      await expect(request("https://api.test.com/endpoint")).rejects.toThrow(
-        InternalServerError,
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(500, "Internal Server Error", {
+          statusText: "Internal Server Error",
+        }),
       );
+
+      await expect(
+        request("https://api.test.com/endpoint"),
+      ).rejects.toMatchObject({
+        name: "InternalServerError",
+        message: "Internal Server Error",
+      });
     });
 
     it("should handle error response with error field", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        json: () => Promise.resolve({ error: "Something went wrong" }),
-        headers: new Headers(),
-      });
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(400, { error: "Something went wrong" }),
+      );
 
-      try {
-        await request("https://api.test.com/endpoint");
-      } catch (error) {
-        expect(error).toBeInstanceOf(BadRequestError);
-        expect((error as BadRequestError).message).toBe("Something went wrong");
-      }
+      await expect(
+        request("https://api.test.com/endpoint"),
+      ).rejects.toMatchObject({
+        name: "BadRequestError",
+        message: "Something went wrong",
+      });
     });
 
     it("should handle error response with nested error.message", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        json: () =>
-          Promise.resolve({ error: { message: "Nested error message" } }),
-        headers: new Headers(),
-      });
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(400, { error: { message: "Nested error message" } }),
+      );
 
-      try {
-        await request("https://api.test.com/endpoint");
-      } catch (error) {
-        expect(error).toBeInstanceOf(BadRequestError);
-        expect((error as BadRequestError).message).toBe("Nested error message");
-      }
+      await expect(
+        request("https://api.test.com/endpoint"),
+      ).rejects.toMatchObject({
+        name: "BadRequestError",
+        message: "Nested error message",
+      });
     });
 
     it("should handle error response with detail field", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 422,
-        json: () => Promise.resolve({ detail: "Validation failed" }),
-        headers: new Headers(),
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(422, { detail: "Validation failed" }),
+      );
+
+      await expect(
+        request("https://api.test.com/endpoint"),
+      ).rejects.toMatchObject({
+        name: "UnprocessableEntityError",
+        message: "Validation failed",
       });
+    });
+
+    it("surfaces error_id / error_type from a 500 agno 3.0 body", async () => {
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(500, {
+          detail: "Failed to migrate database: schema is out of date",
+          error_id: "migration_required_error",
+          error_type: "MigrationRequiredError",
+        }),
+      );
+
+      await expect(
+        request("https://api.test.com/endpoint"),
+      ).rejects.toMatchObject({
+        name: "InternalServerError",
+        status: 500,
+        message: "Failed to migrate database: schema is out of date",
+        errorId: "migration_required_error",
+        errorType: "MigrationRequiredError",
+      });
+    });
+
+    it("leaves errorId undefined for a plain {detail} 404 body", async () => {
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(404, { detail: "Not found" }),
+      );
 
       try {
         await request("https://api.test.com/endpoint");
+        expect.unreachable("request should have thrown");
       } catch (error) {
-        expect(error).toBeInstanceOf(APIError);
-        expect((error as APIError).message).toBe("Validation failed");
+        expect(error).toBeInstanceOf(NotFoundError);
+        expect((error as APIError).errorId).toBeUndefined();
+        expect((error as APIError).errorType).toBeUndefined();
       }
+    });
+
+    it("should throw ConflictError for 409", async () => {
+      mockFetch.mockResolvedValueOnce(
+        errorResponse(409, { detail: "Run is not paused" }),
+      );
+
+      await expect(request("https://api.test.com/endpoint")).rejects.toThrow(
+        ConflictError,
+      );
     });
 
     it("should send JSON body correctly", async () => {
@@ -222,12 +326,7 @@ describe("HTTP Module", () => {
   describe("requestWithRetry", () => {
     it("should retry on 500 errors", async () => {
       mockFetch
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 500,
-          json: () => Promise.resolve({ message: "Server error" }),
-          headers: new Headers(),
-        })
+        .mockResolvedValueOnce(errorResponse(500, { message: "Server error" }))
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
@@ -247,12 +346,9 @@ describe("HTTP Module", () => {
     });
 
     it("should NOT retry on 400 errors", async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 400,
-        json: () => Promise.resolve({ message: "Bad request" }),
-        headers: new Headers(),
-      });
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(errorResponse(400, { message: "Bad request" })),
+      );
 
       await expect(
         requestWithRetry("https://api.test.com/endpoint", {}, 2, 5000),
@@ -262,16 +358,27 @@ describe("HTTP Module", () => {
     });
 
     it("should NOT retry on 404 errors", async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 404,
-        json: () => Promise.resolve({ message: "Not found" }),
-        headers: new Headers(),
-      });
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(errorResponse(404, { message: "Not found" })),
+      );
 
       await expect(
         requestWithRetry("https://api.test.com/endpoint", {}, 2, 5000),
       ).rejects.toThrow(NotFoundError);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should NOT retry on 409 errors", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          errorResponse(409, { detail: "Idempotency key reused" }),
+        ),
+      );
+
+      await expect(
+        requestWithRetry("https://api.test.com/endpoint", {}, 2, 5000),
+      ).rejects.toThrow(ConflictError);
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
@@ -299,12 +406,7 @@ describe("HTTP Module", () => {
 
     it("should retry on 429 rate limit errors", async () => {
       mockFetch
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 429,
-          json: () => Promise.resolve({ message: "Rate limited" }),
-          headers: new Headers(),
-        })
+        .mockResolvedValueOnce(errorResponse(429, { message: "Rate limited" }))
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
@@ -324,12 +426,9 @@ describe("HTTP Module", () => {
     });
 
     it("should throw RateLimitError after exhausting retries on 429", async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 429,
-        json: () => Promise.resolve({ message: "Rate limited" }),
-        headers: new Headers(),
-      });
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(errorResponse(429, { message: "Rate limited" })),
+      );
 
       await expect(
         requestWithRetry("https://api.test.com/endpoint", {}, 1, 5000),
@@ -340,16 +439,35 @@ describe("HTTP Module", () => {
     });
 
     it("should throw InternalServerError after exhausting retries on 500", async () => {
-      mockFetch.mockResolvedValue({
-        ok: false,
-        status: 500,
-        json: () => Promise.resolve({ message: "Server error" }),
-        headers: new Headers(),
-      });
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(errorResponse(500, { message: "Server error" })),
+      );
 
       await expect(
         requestWithRetry("https://api.test.com/endpoint", {}, 1, 5000),
       ).rejects.toThrow(InternalServerError);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps errorId on the error thrown after exhausting retries", async () => {
+      mockFetch.mockImplementation(() =>
+        Promise.resolve(
+          errorResponse(500, {
+            detail: "Database schema is out of date",
+            error_id: "migration_required_error",
+            error_type: "MigrationRequiredError",
+          }),
+        ),
+      );
+
+      await expect(
+        requestWithRetry("https://api.test.com/endpoint", {}, 1, 5000),
+      ).rejects.toMatchObject({
+        name: "InternalServerError",
+        errorId: "migration_required_error",
+        errorType: "MigrationRequiredError",
+      });
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,12 +9,14 @@ import {
   AuthenticationError,
   BadRequestError,
   ComponentsResource,
+  ConflictError,
   DatabaseResource,
   EvalsResource,
   InternalServerError,
   KnowledgeResource,
   MemoriesResource,
   MetricsResource,
+  MigrationFailedError,
   ModelsResource,
   NotFoundError,
   RateLimitError,
@@ -30,6 +32,7 @@ import {
   normalizeFileInput,
 } from "../src/index";
 import type {
+  APIErrorOptions,
   AgentRunEvent,
   Audio,
   ContinueOptions,
@@ -62,6 +65,7 @@ import type {
   MemoryUpdateCompletedEvent,
   MemoryUpdateStartedEvent,
   MigrateOptions,
+  MigrateResult,
   OptimizeMemoriesOptions,
   ResolveApprovalOptions,
   RunCompletedEvent,
@@ -146,10 +150,20 @@ describe("Package Exports", () => {
     expect(BadRequestError).toBeDefined();
     expect(AuthenticationError).toBeDefined();
     expect(NotFoundError).toBeDefined();
+    expect(ConflictError).toBeDefined();
     expect(UnprocessableEntityError).toBeDefined();
     expect(RateLimitError).toBeDefined();
     expect(InternalServerError).toBeDefined();
     expect(RemoteServerUnavailableError).toBeDefined();
+    expect(MigrationFailedError).toBeDefined();
+  });
+
+  it("should export error-identity and migrate-result types", () => {
+    // Type-level check - if this compiles, exports work
+    const _options: APIErrorOptions = { errorId: "migration_required_error" };
+    const _result: MigrateResult = { message: "ok", skipped: [] };
+    expect(_options.errorId).toBe("migration_required_error");
+    expect(_result.message).toBe("ok");
   });
 
   it("should allow instantiation of AgentOSClient", () => {

--- a/tests/resources/database.test.ts
+++ b/tests/resources/database.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AgentOSClient } from "../../src/client";
+import { MigrationFailedError } from "../../src/errors";
 import { DatabaseResource } from "../../src/resources/database";
 
 describe("DatabaseResource", () => {
@@ -46,12 +47,16 @@ describe("DatabaseResource", () => {
       );
     });
 
-    it("returns void", async () => {
-      requestSpy.mockResolvedValueOnce(undefined);
+    it("returns the server's migration summary", async () => {
+      requestSpy.mockResolvedValueOnce({
+        message: "Database migrated successfully to latest version",
+      });
 
       const result = await resource.migrate("my-db");
 
-      expect(result).toBeUndefined();
+      expect(result).toEqual({
+        message: "Database migrated successfully to latest version",
+      });
     });
 
     it("propagates errors", async () => {
@@ -64,8 +69,10 @@ describe("DatabaseResource", () => {
   });
 
   describe("migrateAll()", () => {
+    const ok = { message: "All databases migrated successfully to latest version" };
+
     it("calls POST /databases/all/migrate", async () => {
-      requestSpy.mockResolvedValueOnce(undefined);
+      requestSpy.mockResolvedValueOnce(ok);
 
       await resource.migrateAll();
 
@@ -77,7 +84,7 @@ describe("DatabaseResource", () => {
     });
 
     it("adds target_version query param when provided", async () => {
-      requestSpy.mockResolvedValueOnce(undefined);
+      requestSpy.mockResolvedValueOnce(ok);
 
       await resource.migrateAll({ targetVersion: "3" });
 
@@ -85,6 +92,42 @@ describe("DatabaseResource", () => {
         "POST",
         "/databases/all/migrate?target_version=3",
       );
+    });
+
+    it("resolves the 200 body, including skipped remote databases", async () => {
+      requestSpy.mockResolvedValueOnce({ ...ok, skipped: ["remote-db"] });
+
+      const result = await resource.migrateAll();
+
+      expect(result).toEqual({ ...ok, skipped: ["remote-db"] });
+    });
+
+    it("rejects with MigrationFailedError on a 207 body with failed databases", async () => {
+      // 207 Multi-Status satisfies response.ok, so the transport resolves it
+      requestSpy.mockResolvedValueOnce({
+        message: "Migrated 0/1 databases to latest version",
+        failed: { "agentos-db": "relation already exists" },
+        skipped: ["remote-db"],
+      });
+
+      const promise = resource.migrateAll();
+
+      await expect(promise).rejects.toThrow(MigrationFailedError);
+      await expect(promise).rejects.toMatchObject({
+        status: 207,
+        message: "Migrated 0/1 databases to latest version",
+        failed: { "agentos-db": "relation already exists" },
+        skipped: ["remote-db"],
+      });
+    });
+
+    it("does not throw on an empty failed map", async () => {
+      requestSpy.mockResolvedValueOnce({ ...ok, failed: {} });
+
+      await expect(resource.migrateAll()).resolves.toEqual({
+        ...ok,
+        failed: {},
+      });
     });
 
     it("propagates errors", async () => {


### PR DESCRIPTION
## Summary

agno 3.0 stamps typed failures with `{detail, error_id, error_type}` and reports per-database migration outcomes in the migrate-all body (200 `{message, skipped?}` or 207 Multi-Status `{message, failed, skipped?}`). The SDK discarded all of it: error bodies were reduced to a message, the streaming path never parsed them at all, and `migrate()`/`migrateAll()` were `Promise<void>`, so a 207 resolved as a clean success. Both issues change `src/errors.ts`, so they ship together.

Consumers: ixora-cli#113 branches on `err.errorId === "migration_required_error"`; ixora-cli#115 renders `MigrateResult` / `MigrationFailedError`.

## Changes

- `APIError.errorId` / `APIError.errorType` (optional), taken from a trailing `APIErrorOptions` argument on every error class; `createErrorFromResponse` threads them through. A plain `{detail}` body leaves both `undefined`.
- `parseErrorBody` is exported from `src/http.ts` and returns `{ message, errorId?, errorType? }`; `AgentOSClient.requestStream()` uses it instead of `response.text()`.
- `parseErrorBody` now reads the body once as text and parses it. The old `json()`-then-`text()` fallback could never work against a real `Response`: a failed `json()` has already consumed the stream, so `text()` throws "Body is unusable" and non-JSON error bodies surfaced as `HTTP <status>`. Moving the streaming path onto the parser would have regressed it without this. The http tests now use real `Response` objects on the error path so the behavior is exercised.
- `ConflictError` (409), mapped in `createErrorFromResponse`; not retried by `requestWithRetry`.
- `MigrateResult { message, failed?, skipped? }` is the return type of `migrate()` / `migrateAll()`. `migrateAll()` throws `MigrationFailedError` (status 207, `failed` map, `skipped?`) when `failed` is non-empty — a 207 satisfies `response.ok`, so the parsed body is the only signal.
- Package exports: `ConflictError`, `MigrationFailedError`, `APIErrorOptions`, `MigrateResult`.
- README: `errorId` / `errorType` documented (and the nonexistent `body` property dropped), `errorId` branch and `MigrationFailedError` examples. CHANGELOG `[Unreleased]` entries under **Added** / **Changed**.

Public API: additive. `Promise<void>` -> `Promise<MigrateResult>` is source-compatible for existing callers; the one behavior change is `migrateAll()` throwing on a 207 instead of resolving.

## Verification

```
npm test          # 855 passed (26 files)
npm run typecheck
npm run lint
npm run build
```

Live check: an `npx tsx` script importing from the built `dist/`.

The shared agno 3.0 stack at :8050 (`s2shared`) went unresponsive mid-check. Its uvicorn worker was OOM-killed by the podman VM (`dmesg`: `Out of memory: Killed process ... (python)`; VM at 3.0 / 3.6 GB) and the `--reload` supervisor leaves the dead worker a zombie while still holding the port, so requests hang instead of being refused. I did not restart it. Before it died, it answered plain 404s with `{"detail":"Agent not found"}` and no `error_id` — expected, since ixora passes `base_app=` and agno only registers its handlers on an app it owns (ixora#197 adds it there).

To verify against real agno 3.0 bodies I ran a throwaway vanilla AgentOS (agno 3.0.0, SQLite `probe-db`, owns its FastAPI app so `error_id` is stamped) on :8071:

```
--- database.migrateAll() ---
resolved {"message":"All databases migrated successfully to latest version"}
--- database.migrate("probe-db") ---
resolved {"message":"Database migrated successfully to latest version"}
--- database.migrate("no-such-db")  [404] ---
threw    {"name":"NotFoundError","status":404,"message":"No database found with id 'no-such-db'"}
--- agents.run(unknown agent)  [404, non-streaming] ---
threw    {"name":"NotFoundError","status":404,"message":"Agent not found"}
--- agents.runStream(unknown agent)  [404, streaming] ---
threw    {"name":"NotFoundError","status":404,"message":"Agent not found"}
```

The streaming `message` is the parsed `detail`; before this PR it was the raw text `{"detail":"Agent not found"}`.

Then `ALTER TABLE agno_sessions DROP COLUMN user_id` and a restart, to trip agno's schema check — the exact scenario the CLI consumers handle:

```
--- sessions.list({ dbId: 'probe-db' })  [schema mismatch -> 500] ---
threw    {"name":"InternalServerError","status":500,"message":"Internal server error (MigrationRequiredError)","errorId":"migration_required_error","errorType":"migration_required_error"}
--- database.migrateAll()  [207 Multi-Status] ---
threw    {"name":"MigrationFailedError","status":207,"message":"Migrated 0/1 databases to latest version","failed":{"probe-db":"(sqlite3.OperationalError) no such column: user_id\n[SQL: SELECT session_id, user_id, runs FROM agno_sessions WHERE runs IS NOT NULL]\n(Background on this error at: https://sqlalche.me/e/20/e3q8)"}}
--- branch: err.errorId === 'migration_required_error' -> migrateAll() ---
resolved {"recoveryThrew":{"name":"MigrationFailedError","status":207,"message":"Migrated 0/1 databases to latest version","failed":{"probe-db":"..."}}}
```

Raw bodies behind those, via curl:

```
GET  /sessions?type=agent&db_id=probe-db
500 {"detail":"Internal server error (MigrationRequiredError)","error_id":"migration_required_error","error_type":"migration_required_error"}

POST /databases/all/migrate
207 {"message":"Migrated 0/1 databases to latest version","failed":{"probe-db":"(sqlite3.OperationalError) no such column: user_id ..."}}
```

Two observations worth knowing:

- `error_type` is agno's snake_case `type`, which every `AgnoError` subclass sets to the same value as `error_id`. The docs say to branch on `errorId` and treat `errorType` as informational.
- A model failure *during* a run is not an HTTP error: non-streaming returns 200 with `status: "ERROR"`, streaming emits a `RunError` event. That event carries an `error_type` the SDK does not type yet — filed #21.

Closes #4
Closes #5
