### PR TITLE
fix: agno 3.0 follow-ups — workflows.continue step_requirements, RunError identity, VERSION, README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ This project follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `workflows.continue()` sends human-in-the-loop resolutions as the
+  `step_requirements` form field that
+  `POST /workflows/{id}/runs/{run_id}/continue` reads. It used to post `tools`,
+  which only the agent route reads; the workflow route swept it into unread
+  kwargs, so a paused workflow run continued through the SDK was never
+  resolved. `WorkflowContinueOptions` gains `stepRequirements` (JSON array: the
+  paused run's `step_requirements[]` with the active — last — entry resolved,
+  e.g. `confirmed`, `user_input`, `selected_choices`, or `confirmed` on each
+  `executor_requirements[].tool_execution`; every entry keeps its `step_id`).
+  `tools` is deprecated and now throws a `TypeError` instead of being posted:
+  the workflow route has no `tool_execution` wrapper, and a bare tool list
+  cannot be mapped onto a `StepRequirement` without the paused step's
+  `step_id`, so there is no wrap that would not 400 server-side.
+- `RunErrorEvent` and `TeamRunErrorEvent` type the failure identity agno >= 3.0
+  stamps on run-error stream events: `error_type` (e.g.
+  `"model_provider_error"`), `error_id` and `additional_data`, all optional.
+  The workflow-level `WorkflowError` event (`error`, `error_type`, `error_id`,
+  `additional_data`) was missing from the SDK entirely: `WorkflowErrorEvent`
+  is now part of `WorkflowRunEvent` / `EventMap`, and
+  `WorkflowEventType.WorkflowError` / `RunEventType.WorkflowError` exist.
+- `VERSION` (and therefore `client.version` and the `User-Agent` header) is
+  read from `package.json` at build time instead of a hand-maintained literal
+  in `src/index.ts`, which had stayed at `0.4.0` through 0.5.0 - 0.6.2. The
+  test that pinned the literal now compares against `package.json`, and
+  `RELEASING.md` no longer asks for a second manual bump.
+- README API reference matches the client: `baseUrl` is required (the SDK
+  reads no `AGENTOS_API_KEY` env var), `timeout` defaults to 30000 and
+  `maxRetries` to 2, `headers` is documented, and the `metrics.get()` /
+  `traces.list()` snippets use the camelCase option keys the resources take.
+
 ### Changed
 
 - Regenerated `openapi.json` and `src/generated/types.ts` from an AgentOS running

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ TypeScript SDK for the AgentOS HTTP API. Run agents, teams, and workflows with s
 ```typescript
 import { AgentOSClient } from '@worksofadam/agentos-sdk';
 
-const client = new AgentOSClient({ apiKey: process.env.AGENTOS_API_KEY });
+const client = new AgentOSClient({
+  baseUrl: 'http://localhost:7777', // required
+  apiKey: 'your-api-key',           // optional; the SDK reads no environment variables
+});
 const stream = await client.agents.runStream('agent-id', { message: 'Hello!' });
 for await (const event of stream) {
   if (event.event === 'RunContent') console.log(event.content);
@@ -37,7 +40,7 @@ pnpm add @worksofadam/agentos-sdk
 
 **List all agents:**
 ```typescript
-const client = new AgentOSClient({ apiKey: 'your-api-key' });
+const client = new AgentOSClient({ baseUrl: 'http://localhost:7777', apiKey: 'your-api-key' });
 const agents = await client.agents.list();
 console.log(agents);
 ```
@@ -140,6 +143,21 @@ const result = await client.workflows.run('workflow-id', {
   sessionId: 'session-123'
 });
 console.log(result);
+```
+
+**Continue a paused workflow run:**
+```typescript
+// The paused run (WorkflowPaused event or getRun()) carries step_requirements[];
+// the LAST entry is the active pause. Stamp the decision on it and send the
+// whole array back: the server replaces its stored list with what you send.
+// (Agents take `tools`, teams take `requirements`; workflows differ.)
+const reqs = paused.step_requirements;
+reqs[reqs.length - 1].confirmed = true; // or user_input / selected_choices
+
+const stream = await client.workflows.continue('workflow-id', paused.run_id, {
+  stepRequirements: JSON.stringify(reqs),
+  sessionId: paused.session_id
+});
 ```
 
 ### Sessions
@@ -273,10 +291,9 @@ if (status.status === 'completed') {
 **List traces with filtering:**
 ```typescript
 const traces = await client.traces.list({
-  run_id: 'run-123',
-  session_id: 'session-456',
-  starting_date: '2024-01-01',
-  ending_date: '2024-01-31'
+  runId: 'run-123',
+  sessionId: 'session-456',
+  limit: 50
 });
 console.log(traces);
 ```
@@ -285,10 +302,12 @@ console.log(traces);
 
 **Get metrics:**
 ```typescript
+// GetMetricsOptions: startingDate / endingDate (YYYY-MM-DD), userId, dbId.
+// There is no session filter; GET /metrics aggregates per day.
 const metrics = await client.metrics.get({
-  session_id: 'session-123',
-  starting_date: '2024-01-01',
-  ending_date: '2024-01-31'
+  startingDate: '2024-01-01',
+  endingDate: '2024-01-31',
+  userId: 'user-123'
 });
 console.log(metrics);
 ```
@@ -385,6 +404,33 @@ try {
   }
 }
 ```
+
+### Run Errors
+
+A run that fails after the stream has started does not raise an HTTP error:
+the server ends the stream with a `RunError` event (`TeamRunError` for teams,
+`WorkflowError` for workflows, where the message field is `error` rather than
+`content`). On agno >= 3.0 that event carries the same machine-readable
+identity agno puts in HTTP error bodies (`error_type` / `error_id`, e.g.
+`"model_provider_error"`), so you can branch on the failure kind instead of
+matching the message text:
+
+```typescript
+for await (const event of stream) {
+  if (event.event === 'RunError') {
+    if (event.error_type === 'model_provider_error') {
+      console.error('Model provider rejected the request:', event.content);
+    } else {
+      console.error('Run failed:', event.error_type ?? 'unknown', event.content);
+    }
+  }
+}
+```
+
+`error_type`, `error_id` and `additional_data` are `undefined` on servers older
+than agno 3.0. Non-streaming runs report the same failures as a 200 response
+with `status: "ERROR"` and the message in `content`, so the stream event is the
+only place the identity is exposed.
 
 ## File Uploads
 
@@ -572,11 +618,14 @@ of its handler) in `openapi.json`.
 new AgentOSClient(options: AgentOSClientOptions)
 ```
 
-**Options:**
-- `apiKey?: string` - API key for authentication (can also use `AGENTOS_API_KEY` env var)
-- `baseUrl?: string` - Base URL for API (default: `https://api.agno.com`)
-- `timeout?: number` - Request timeout in milliseconds (default: 60000)
-- `maxRetries?: number` - Maximum retry attempts (default: 3)
+**Options** (`AgentOSClientOptions`):
+- `baseUrl: string` - Base URL of the AgentOS server (required; the constructor throws without it)
+- `apiKey?: string` - API key sent as a `Bearer` token. The SDK reads no environment variables; pass the value yourself
+- `timeout?: number` - Request timeout in milliseconds (default: 30000)
+- `maxRetries?: number` - Maximum retry attempts for transient failures (default: 2)
+- `headers?: Record<string, string>` - Extra headers sent with every request
+
+`client.version` exposes the SDK version (also sent as `User-Agent: agentos-sdk/<version>`); it is read from `package.json` at build time.
 
 **Methods:**
 - `getConfig(): Promise<ConfigResponse>` - Get server configuration (`components['schemas']['ConfigResponse']`)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -52,11 +52,10 @@ npm version minor --no-git-tag-version
 npm version major --no-git-tag-version
 ```
 
-Also update the version in `src/index.ts`:
-
-```typescript
-export const VERSION = "0.1.1"; // Update to match package.json
-```
+`package.json` is the only place the version lives: `VERSION` in
+`src/index.ts` (exposed as `client.version` and sent in the `User-Agent`
+header) is read from `package.json` at build time, and `tests/index.test.ts`
+asserts the two match.
 
 ### Step 3: Update Changelog (Optional)
 
@@ -65,7 +64,7 @@ If you maintain a CHANGELOG.md, update it with the new version's changes.
 ### Step 4: Commit Version Bump
 
 ```bash
-git add package.json package-lock.json src/client.ts
+git add package.json package-lock.json
 git commit -m "chore: bump version to X.Y.Z"
 git push origin main
 ```
@@ -170,5 +169,5 @@ git push origin vX.Y.Z
 
 - `.github/workflows/publish.yml` - Publish workflow
 - `.github/workflows/ci.yml` - CI workflow (runs on PRs)
-- `package.json` - Package configuration
-- `src/client.ts` - Contains version constant
+- `package.json` - Package configuration and the single source of the version
+- `src/index.ts` - Exports `VERSION`, read from `package.json` at build time

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,13 @@
  * @packageDocumentation
  */
 
-// Version
-export const VERSION = "0.4.0";
+import { version } from "../package.json";
+
+/**
+ * SDK version, read from `package.json` at build time so it cannot drift
+ * from the published package version. Sent as `User-Agent: agentos-sdk/<VERSION>`.
+ */
+export const VERSION: string = version;
 
 // Client
 export { AgentOSClient } from "./client";
@@ -223,9 +228,10 @@ export type {
   TeamOutputModelResponseStartedEvent,
   TeamOutputModelResponseCompletedEvent,
   TeamCustomEvent,
-  // Workflow event interfaces (18)
+  // Workflow event interfaces (19)
   WorkflowStartedEvent,
   WorkflowCompletedEvent,
+  WorkflowErrorEvent,
   WorkflowCancelledEvent,
   StepStartedEvent,
   StepCompletedEvent,

--- a/src/resources/workflows.ts
+++ b/src/resources/workflows.ts
@@ -56,10 +56,36 @@ export interface WorkflowStreamRunOptions {
 
 /**
  * Options for continuing a paused workflow run
+ *
+ * The workflow continue route resolves human-in-the-loop pauses from the
+ * `step_requirements` form field (the agent route's `tools` field and the
+ * team route's `requirements` field are ignored here). Send back the
+ * `step_requirements[]` array from the paused run (the `WorkflowPaused`
+ * event or `getRun()`), with the decision stamped on the LAST entry: the
+ * server replaces the stored list with what you send and treats the last
+ * entry as the active requirement (earlier entries are resolved history).
+ * Each entry must keep its `step_id`. Stamp `confirmed: true | false` for a
+ * confirmation pause, `user_input` for a user-input pause,
+ * `selected_choices` for a router pause, or `confirmed` on each
+ * `executor_requirements[].tool_execution` for an agent/team tool pause
+ * inside a step.
  */
 export interface WorkflowContinueOptions {
-  /** JSON string containing array of tool execution results */
-  tools: string;
+  /**
+   * JSON string containing the paused run's `step_requirements` array with
+   * the active (last) entry resolved (see interface doc). May be omitted when
+   * the server can resolve the pause itself (e.g. a timed-out requirement
+   * with an `on_timeout` policy).
+   */
+  stepRequirements?: string;
+  /**
+   * @deprecated The workflow route reads `step_requirements`, not `tools`,
+   * and a bare tool-execution list cannot be mapped onto a `StepRequirement`
+   * (which needs the paused step's `step_id`). Passing this throws a
+   * `TypeError`; pass `stepRequirements` instead. It used to be posted as
+   * `tools`, which the server dropped silently.
+   */
+  tools?: string;
   /** Optional session ID */
   sessionId?: string;
   /** Optional user ID */
@@ -266,20 +292,41 @@ export class WorkflowsResource {
   }
 
   /**
-   * Continue a paused workflow run with tool results.
+   * Continue a paused workflow run with resolved step requirements.
    *
    * @param workflowId - The workflow identifier
    * @param runId - The run identifier to continue
-   * @param options - Continue options including tool results
+   * @param options - Continue options including the resolved step requirements
    * @returns AgentStream if streaming, otherwise the run result
+   *
+   * @example
+   * ```typescript
+   * // `paused` is the WorkflowPaused event (or getRun() output); confirm the
+   * // active requirement, which is the last entry of step_requirements
+   * const reqs = paused.step_requirements;
+   * reqs[reqs.length - 1].confirmed = true;
+   * const stream = await client.workflows.continue('workflow-id', paused.run_id, {
+   *   stepRequirements: JSON.stringify(reqs),
+   *   sessionId: paused.session_id,
+   * });
+   * ```
    */
   async continue(
     workflowId: string,
     runId: string,
     options: WorkflowContinueOptions,
   ): Promise<AgentStream | unknown> {
+    if (options.tools !== undefined && options.stepRequirements === undefined) {
+      throw new TypeError(
+        "WorkflowContinueOptions.tools is not supported: the workflow continue route reads step_requirements, " +
+          "and a tool-execution list cannot be mapped onto a StepRequirement. Pass stepRequirements " +
+          "(the paused run's step_requirements[] with the last entry resolved) instead.",
+      );
+    }
     const formData = new FormData();
-    formData.append("tools", options.tools);
+    if (options.stepRequirements !== undefined) {
+      formData.append("step_requirements", options.stepRequirements);
+    }
     formData.append("stream", String(options.stream ?? true));
 
     if (options.sessionId) {

--- a/src/streaming/events/agent.ts
+++ b/src/streaming/events/agent.ts
@@ -131,11 +131,24 @@ export interface RunContinuedEvent extends BaseAgentRunEvent {
 /**
  * Error event during agent run.
  *
+ * agno >= 3.0 stamps run-level failures with the same machine-readable
+ * identity it puts in HTTP error bodies (`error_type` / `error_id`, e.g.
+ * `"model_provider_error"`), so consumers can branch on the failure kind
+ * instead of matching `content` text. Non-streaming runs report these
+ * failures as a 200 with `status: "ERROR"`, so this event is the only place
+ * the identity is exposed.
+ *
  * @public
  */
 export interface RunErrorEvent extends BaseAgentRunEvent {
   event: "RunError";
   content: string;
+  /** Machine-readable failure kind (agno >= 3.0), e.g. `"model_provider_error"` */
+  error_type?: string;
+  /** Stable error identifier (agno >= 3.0); agno currently mirrors `error_type` */
+  error_id?: string;
+  /** Extra structured context attached by the raising exception */
+  additional_data?: Record<string, unknown>;
 }
 
 /**

--- a/src/streaming/events/constants.ts
+++ b/src/streaming/events/constants.ts
@@ -105,7 +105,7 @@ export const TeamEventType = {
 } as const;
 
 /**
- * Constants for workflow streaming event types (18 events).
+ * Constants for workflow streaming event types (19 events).
  *
  * @public
  */
@@ -113,6 +113,7 @@ export const WorkflowEventType = {
   // Lifecycle
   WorkflowStarted: "WorkflowStarted",
   WorkflowCompleted: "WorkflowCompleted",
+  WorkflowError: "WorkflowError",
   WorkflowCancelled: "WorkflowCancelled",
 
   // Steps

--- a/src/streaming/events/index.ts
+++ b/src/streaming/events/index.ts
@@ -110,6 +110,7 @@ export type {
   WorkflowRunEvent,
   WorkflowStartedEvent,
   WorkflowCompletedEvent,
+  WorkflowErrorEvent,
   WorkflowCancelledEvent,
   StepStartedEvent,
   StepCompletedEvent,

--- a/src/streaming/events/team.ts
+++ b/src/streaming/events/team.ts
@@ -109,11 +109,20 @@ export interface TeamRunCompletedEvent extends BaseTeamRunEvent {
 /**
  * Team run error event.
  *
+ * Carries the same agno >= 3.0 failure identity as the agent `RunError`
+ * event; see `RunErrorEvent`.
+ *
  * @public
  */
 export interface TeamRunErrorEvent extends BaseTeamRunEvent {
   event: "TeamRunError";
   content: string;
+  /** Machine-readable failure kind (agno >= 3.0), e.g. `"model_provider_error"` */
+  error_type?: string;
+  /** Stable error identifier (agno >= 3.0); agno currently mirrors `error_type` */
+  error_id?: string;
+  /** Extra structured context attached by the raising exception */
+  additional_data?: Record<string, unknown>;
 }
 
 /**

--- a/src/streaming/events/workflow.ts
+++ b/src/streaming/events/workflow.ts
@@ -1,5 +1,5 @@
 /**
- * Workflow streaming event interfaces (18 event types).
+ * Workflow streaming event interfaces (19 event types).
  *
  * @packageDocumentation
  */
@@ -33,6 +33,26 @@ export interface WorkflowStartedEvent extends BaseWorkflowRunEvent {
  */
 export interface WorkflowCompletedEvent extends BaseWorkflowRunEvent {
   event: "WorkflowCompleted";
+}
+
+/**
+ * Workflow error event.
+ *
+ * The workflow-level counterpart of the agent `RunError` event. Note the
+ * message field is `error`, not `content`. Carries the same agno >= 3.0
+ * failure identity (`error_type` / `error_id`); see `RunErrorEvent`.
+ *
+ * @public
+ */
+export interface WorkflowErrorEvent extends BaseWorkflowRunEvent {
+  event: "WorkflowError";
+  error?: string;
+  /** Machine-readable failure kind (agno >= 3.0), e.g. `"model_provider_error"` */
+  error_type?: string;
+  /** Stable error identifier (agno >= 3.0); agno currently mirrors `error_type` */
+  error_id?: string;
+  /** Extra structured context attached by the raising exception */
+  additional_data?: Record<string, unknown>;
 }
 
 /**
@@ -280,13 +300,14 @@ export interface StepsExecutionCompletedEvent extends BaseWorkflowRunEvent {
 // ---------------------------------------------------------------------------
 
 /**
- * Discriminated union of all workflow run streaming events (18 types).
+ * Discriminated union of all workflow run streaming events (19 types).
  *
  * @public
  */
 export type WorkflowRunEvent =
   | WorkflowStartedEvent
   | WorkflowCompletedEvent
+  | WorkflowErrorEvent
   | WorkflowCancelledEvent
   | StepStartedEvent
   | StepCompletedEvent

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { version as packageVersion } from "../package.json";
 import {
   APIError,
   AgentOSClient,
@@ -91,7 +92,9 @@ describe("Package Exports", () => {
     expect(typeof VERSION).toBe("string");
     // Verify semver format (X.Y.Z)
     expect(VERSION).toMatch(/^\d+\.\d+\.\d+$/);
-    expect(VERSION).toBe("0.4.0");
+    // VERSION is read from package.json at build time; a literal pin here let
+    // the two drift for three releases (0.5.0 - 0.6.2 shipped as "0.4.0").
+    expect(VERSION).toBe(packageVersion);
   });
 
   it("should export AgentOSClient", () => {

--- a/tests/resources/workflows.test.ts
+++ b/tests/resources/workflows.test.ts
@@ -361,7 +361,7 @@ describe("WorkflowsResource", () => {
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
       const result = await resource.continue("workflow-1", "run-123", {
-        tools: "[]",
+        stepRequirements: "[]",
       });
 
       expect(result).toBeInstanceOf(AgentStream);
@@ -384,7 +384,7 @@ describe("WorkflowsResource", () => {
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
       const result = await resource.continue("workflow-1", "run-123", {
-        tools: "[]",
+        stepRequirements: "[]",
         stream: true,
       });
 
@@ -396,7 +396,7 @@ describe("WorkflowsResource", () => {
       requestSpy.mockResolvedValueOnce(mockResult);
 
       const result = await resource.continue("workflow-1", "run-123", {
-        tools: "[]",
+        stepRequirements: "[]",
         stream: false,
       });
 
@@ -412,16 +412,95 @@ describe("WorkflowsResource", () => {
       expect(formData.get("stream")).toBe("false");
     });
 
-    it("includes tools parameter", async () => {
+    it("posts stepRequirements as the step_requirements form field, never tools", async () => {
       const mockResponse = new Response("data: event", { status: 200 });
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
-      const toolsJSON = '[{"name":"get_weather","result":"sunny"}]';
-      await resource.continue("workflow-1", "run-123", { tools: toolsJSON });
+      // The paused run's step_requirements[] with the active (last) entry
+      // confirmed - the shape agno's StepRequirement.from_dict reads.
+      const stepRequirementsJSON = JSON.stringify([
+        {
+          step_id: "step-1",
+          step_name: "review",
+          step_index: 0,
+          step_type: "Step",
+          requires_confirmation: true,
+          confirmation_message: "Run the query?",
+          confirmed: true,
+          on_reject: "cancel",
+        },
+      ]);
+      await resource.continue("workflow-1", "run-123", {
+        stepRequirements: stepRequirementsJSON,
+      });
 
       const callArgs = requestStreamSpy.mock.calls[0];
       const formData = callArgs[2].body as FormData;
-      expect(formData.get("tools")).toBe(toolsJSON);
+      expect(formData.get("step_requirements")).toBe(stepRequirementsJSON);
+      expect(formData.has("tools")).toBe(false);
+      expect(formData.has("requirements")).toBe(false);
+    });
+
+    it("posts step_requirements on the non-streaming path too", async () => {
+      requestSpy.mockResolvedValueOnce({ run_id: "run-123" });
+
+      await resource.continue("workflow-1", "run-123", {
+        stepRequirements: '[{"step_id":"step-1","confirmed":false}]',
+        stream: false,
+      });
+
+      const callArgs = requestSpy.mock.calls[0];
+      const formData = callArgs[2].body as FormData;
+      expect(formData.get("step_requirements")).toBe(
+        '[{"step_id":"step-1","confirmed":false}]',
+      );
+      expect(formData.has("tools")).toBe(false);
+    });
+
+    it("omits step_requirements when not provided", async () => {
+      const mockResponse = new Response("data: event", { status: 200 });
+      requestStreamSpy.mockResolvedValueOnce(mockResponse);
+
+      await resource.continue("workflow-1", "run-123", {
+        sessionId: "session-456",
+      });
+
+      const callArgs = requestStreamSpy.mock.calls[0];
+      const formData = callArgs[2].body as FormData;
+      expect(formData.has("step_requirements")).toBe(false);
+      expect(formData.has("tools")).toBe(false);
+    });
+
+    it("throws on the deprecated tools option instead of posting it", async () => {
+      await expect(
+        resource.continue("workflow-1", "run-123", {
+          tools: '[{"tool_call_id":"call_1","confirmed":true}]',
+        }),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        resource.continue("workflow-1", "run-123", {
+          tools: '[{"tool_call_id":"call_1","confirmed":true}]',
+        }),
+      ).rejects.toThrow(/step_requirements/);
+      expect(requestStreamSpy).not.toHaveBeenCalled();
+      expect(requestSpy).not.toHaveBeenCalled();
+    });
+
+    it("ignores deprecated tools when stepRequirements is also provided", async () => {
+      const mockResponse = new Response("data: event", { status: 200 });
+      requestStreamSpy.mockResolvedValueOnce(mockResponse);
+
+      await resource.continue("workflow-1", "run-123", {
+        stepRequirements: '[{"step_id":"step-1","confirmed":true}]',
+        tools: '[{"tool_call_id":"call_1","confirmed":true}]',
+      });
+
+      const callArgs = requestStreamSpy.mock.calls[0];
+      const formData = callArgs[2].body as FormData;
+      expect(formData.get("step_requirements")).toBe(
+        '[{"step_id":"step-1","confirmed":true}]',
+      );
+      expect(formData.has("tools")).toBe(false);
     });
 
     it("includes session_id when provided", async () => {
@@ -429,7 +508,7 @@ describe("WorkflowsResource", () => {
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
       await resource.continue("workflow-1", "run-123", {
-        tools: "[]",
+        stepRequirements: "[]",
         sessionId: "session-456",
       });
 
@@ -440,10 +519,10 @@ describe("WorkflowsResource", () => {
 
     it("includes user_id when provided", async () => {
       const mockResponse = new Response("data: event", { status: 200 });
-      requestStreamSpy.mock.calls[0];
+      requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
       await resource.continue("workflow-1", "run-123", {
-        tools: "[]",
+        stepRequirements: "[]",
         userId: "user-789",
       });
 
@@ -456,7 +535,9 @@ describe("WorkflowsResource", () => {
       const mockResponse = new Response("data: event", { status: 200 });
       requestStreamSpy.mockResolvedValueOnce(mockResponse);
 
-      await resource.continue("workflow/special", "run/123", { tools: "[]" });
+      await resource.continue("workflow/special", "run/123", {
+        stepRequirements: "[]",
+      });
 
       expect(requestStreamSpy).toHaveBeenCalledWith(
         "POST",

--- a/tests/streaming/events.test.ts
+++ b/tests/streaming/events.test.ts
@@ -45,8 +45,10 @@ import {
   type TeamPreHookStartedEvent,
   type TeamSessionSummaryCompletedEvent,
   type TeamCustomEvent,
+  type TeamRunErrorEvent,
   type WorkflowStartedEvent,
   type WorkflowCompletedEvent,
+  type WorkflowErrorEvent,
   type WorkflowCancelledEvent,
   type StepStartedEvent,
   type StepCompletedEvent,
@@ -409,13 +411,14 @@ describe("streaming event types", () => {
   });
 
   describe("WorkflowEventType constants", () => {
-    it("has 18 workflow event type constants", () => {
-      expect(Object.keys(WorkflowEventType)).toHaveLength(18);
+    it("has 19 workflow event type constants", () => {
+      expect(Object.keys(WorkflowEventType)).toHaveLength(19);
     });
 
     it("includes all expected workflow event types", () => {
       expect(WorkflowEventType.WorkflowStarted).toBe("WorkflowStarted");
       expect(WorkflowEventType.WorkflowCompleted).toBe("WorkflowCompleted");
+      expect(WorkflowEventType.WorkflowError).toBe("WorkflowError");
       expect(WorkflowEventType.WorkflowCancelled).toBe("WorkflowCancelled");
       expect(WorkflowEventType.StepStarted).toBe("StepStarted");
       expect(WorkflowEventType.StepCompleted).toBe("StepCompleted");
@@ -559,6 +562,36 @@ describe("streaming event types", () => {
       };
 
       expect(event.content).toBe("Error message");
+      expect(event.error_type).toBeUndefined();
+    });
+
+    it("RunErrorEvent types the agno 3.0 error identity fields", () => {
+      // Shape observed from a vanilla agno 3.0.0 AgentOS run-error stream event
+      const event: RunErrorEvent = {
+        event: "RunError",
+        created_at: 1788535298,
+        agent_id: "probe-agent",
+        content: "Incorrect API key provided: sk-bogus...",
+        error_type: "model_provider_error",
+        error_id: "model_provider_error",
+        additional_data: { provider: "openai" },
+      };
+
+      expect(event.error_type).toBe("model_provider_error");
+      expect(event.error_id).toBe("model_provider_error");
+      expect(event.additional_data?.provider).toBe("openai");
+    });
+
+    it("TeamRunErrorEvent types the agno 3.0 error identity fields", () => {
+      const event: TeamRunErrorEvent = {
+        event: "TeamRunError",
+        created_at: Date.now(),
+        content: "Member failed",
+        error_type: "model_provider_error",
+      };
+
+      expect(event.error_type).toBe("model_provider_error");
+      expect(event.error_id).toBeUndefined();
     });
 
     it("RunContentCompletedEvent is constructible", () => {
@@ -690,6 +723,26 @@ describe("streaming event types", () => {
 
       expect(event.reason).toBe("timeout");
       expect(event.is_cancelled).toBe(true);
+    });
+
+    it("WorkflowErrorEvent has error and the agno 3.0 error identity fields", () => {
+      const event: WorkflowErrorEvent = {
+        event: "WorkflowError",
+        created_at: Date.now(),
+        error: "Step 'review' failed",
+        error_type: "model_provider_error",
+        error_id: "model_provider_error",
+      };
+
+      expect(event.error).toBe("Step 'review' failed");
+      expect(event.error_type).toBe("model_provider_error");
+    });
+
+    it("WorkflowErrorEvent narrows through the EventMap", () => {
+      const handler = (event: EventMap["WorkflowError"]) => event.error_type;
+      expect(
+        handler({ event: "WorkflowError", created_at: 1, error_type: "x" }),
+      ).toBe("x");
     });
 
     it("StepStartedEvent has step fields", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "rootDir": "./src",
 
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "isolatedModules": true
   },


### PR DESCRIPTION
## Summary

Four small follow-ups from the agno 3.0 section-2 sweep, in one PR. No version bump (stays 0.6.2; ships in 0.7.0 per the `[Unreleased]` changelog).

- **#20** `workflows.continue()` posted `tools`; `POST /workflows/{id}/runs/{run_id}/continue` reads `step_requirements` (agno 3.0.0 `os/routers/workflows/router.py:2064`, parsed at `:2084`, `StepRequirement.from_dict` at `:2181`). The unread field was swept into kwargs, so a paused workflow run continued through the SDK was never resolved.
- **#21** agno 3.0 stamps `error_type` / `error_id` / `additional_data` on run-error stream events (`RunErrorEvent` in `run/agent.py:320`, `run/team.py:294`, `WorkflowErrorEvent` in `run/workflow.py:243`); the SDK typed only `content`.
- **#22** `VERSION` in `src/index.ts` was stuck at `0.4.0` through 0.5.0–0.6.2 (a literal pin in the test hid it), so `User-Agent` and `client.version` misreported.
- **#19** README API reference described a client that does not exist (optional `baseUrl` with a default, `AGENTOS_API_KEY` env var, timeout 60000, maxRetries 3, snake_case `metrics.get()` keys).

## Changes

**`workflows.continue()` (#20)** — `src/resources/workflows.ts`
- `WorkflowContinueOptions.stepRequirements?: string`, sent as the `step_requirements` form field. Contract (from the route + `Workflow.continue_run`, `workflow/workflow.py:6552-6558`): send the paused run's **whole `step_requirements[]` array** (from the `WorkflowPaused` event or `getRun()`) with the decision stamped on the **last** entry — the server replaces its stored list with what you send and treats the last entry as the active requirement. Every entry keeps its `step_id` (`from_dict` does `data["step_id"]`). Stamp `confirmed: true|false` (confirmation), `user_input` (user-input), `selected_choices` (router), or `confirmed` on each `executor_requirements[].tool_execution` (agent/team tool pause inside a step).
- `tools` is kept as a `@deprecated` optional field but **throws a `TypeError`** rather than being wrapped. This deliberately differs from #23's `teams.continue()` (which wraps `tools` entries as `{ tool_execution }`): the workflow route has no `tool_execution` wrapper equivalent, and a bare tool-execution list cannot be turned into a `StepRequirement` without the paused step's `step_id`, so any wrap would 400 server-side (`Invalid structure or content for step_requirements: 'step_id'`). Failing fast client-side with the fix in the message is the honest replacement for the silent drop. `stepRequirements` wins when both are passed.
- ixora-cli callers (`src/lib/chat/runner.ts`, `src/lib/agentos-runs-command.ts`) build one `{ tools }` object for agents/teams/workflows; the workflow branch must build the `stepRequirements` payload above instead — tracked on the ixora-cli side.

**Run-error identity (#21)** — `src/streaming/events/{agent,team,workflow}.ts`, `constants.ts`, barrel + `src/index.ts`
- `RunErrorEvent` / `TeamRunErrorEvent` gain optional `error_type`, `error_id`, `additional_data` (the exact field set of the agno dataclasses).
- The workflow-level `WorkflowError` event was missing from the SDK entirely: new `WorkflowErrorEvent` (`event: "WorkflowError"`, `error`, `error_type`, `error_id`, `additional_data`) in `WorkflowRunEvent` / `EventMap`, plus `WorkflowEventType.WorkflowError` (workflow count 18 → 19). Additive.

**VERSION (#22)** — `src/index.ts`, `tsconfig.json`, `tests/index.test.ts`, `RELEASING.md`
- `export const VERSION: string = version` from `import { version } from "../package.json"` (`resolveJsonModule: true`). esbuild tree-shakes it to `var version = "0.6.2"` in both `dist/index.js` and `dist/index.cjs` (no package.json contents leak into the bundle); the d.ts is `declare const VERSION: string`. Works under tsup, vitest and tsx with no extra `define` plumbing.
- The test compares `VERSION` to `package.json`'s `version`; `RELEASING.md` drops the second manual bump and fixes the `git add` list (it named `src/client.ts`, which never held the constant).

**README (#19)** — constructor options match `AgentOSClientOptions` (`baseUrl` required, no env var, timeout 30000, maxRetries 2, `headers`); Quick Start / list-agents snippets pass `baseUrl`; `metrics.get()` uses `startingDate` / `endingDate` / `userId` (there is no session filter). Also fixed the adjacent `traces.list()` snippet, which had the same snake_case drift and used `starting_date` / `ending_date` keys `ListTracesOptions` does not have. Added a "Run Errors" subsection under Streaming for #21 and a "Continue a paused workflow run" snippet for #20.

**CHANGELOG** — one `### Fixed` section inserted directly under `## [Unreleased]`. Placed there (not at the top of the existing lists as the sweep convention says) because #18 already inserts at the top of `Changed`/`Added`/`Breaking` and #24 appends to the bottom of `Changed`/`Added`, leaving no conflict-free slot inside those lists; #23 adds its own `### Fixed` after `Breaking`, so after all four merge there will be two `### Fixed` blocks to fold together in one follow-up edit.

## Verification

- `npm test` (837 tests), `npm run typecheck`, `npm run lint`, `npm run build` green locally.
- **Live check against the agno 3.0 ixora stack at `http://localhost:8050`** (auth off) with an `npx tsx` script importing the built `dist/`, wrapping `fetch` as a request spy — 16/16 checks pass:
  - #22: `VERSION === package.json.version === client.version === "0.6.2"`; a real `GET /health` went out with `User-Agent: agentos-sdk/0.6.2`.
  - #20: the stack registers **no workflows** (`GET /workflows` → `[]`, `/info.workflow_count: 0`), so there is no HITL pause to drive end-to-end — that limitation stands. What was verified live instead: the route parses `step_requirements` **before** resolving the workflow, so `workflows.continue('no-such-workflow', …, { stepRequirements: 'not json' })` returns **400 `Invalid JSON in step_requirements field`** (proves the field is read), a valid payload returns 404 `Workflow not found`, and a raw POST with only the old `tools` field returns 404 — never 400 — even with garbage (reproduces the silent drop). Spy confirmed the multipart body carries `step_requirements` + `stream` and no `tools`; the deprecated `tools` option throws before any request.
  - #21: a synthetic SSE stream with the exact `RunError` payload from the issue plus a `WorkflowError` event parses through `AgentStream` with `error_type` / `error_id` typed (no cast) and `WorkflowError` narrowing via the union. Live smoke: `agents.runStream('ibmi-agent')` on the stack completes `RunStarted → … → RunCompleted` with no `RunError`.
- **Trial merge** in a throwaway worktree off `origin/main` (removed afterwards): `git merge` of `feat/error-identity-migrate-result` (#24), `feat/agno3-info-restore-metrics` (#18), `fix/session-workflow-team-request-shapes` (#23), then this branch — all four merged with **no conflicts**; on the merged tree `npm run typecheck` ✓, `npm run lint` ✓, `npx vitest run` → 26 files, **891 passed**.

Found while verifying, filed separately: #25 (34 agno 3.0 stream event types missing from the typings, including the `TeamRunPaused` / `WorkflowPaused` / `StepPaused` events the continue contracts depend on).

Closes #20
Closes #21
Closes #22
Closes #19