### PR TITLE
ci: run the CI workflow on every pull request, not only PRs targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # No branches filter: stacked PRs (base = another feature branch) must get
+  # checks too, not only PRs targeting main.
   pull_request:
-    branches: [main]
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` triggered on `pull_request: branches: [main]` only, so a PR whose base is another feature branch (the agno 3.0 stack: #29 -> `fix/agno3-followups`, #30 -> `feat/agno3-stream-event-types`) got no lint / typecheck / Node 18-20-22 test / validate checks at all. The `branches` filter under `pull_request` is dropped so the workflow runs for every PR regardless of base; `push: branches: [main]` is unchanged and the publish/release workflows are untouched. No job changes. Closes #31.

## When stacked PRs start getting checks

GitHub evaluates the workflow file from the PR's merge commit (PR head merged into its base). So an open stacked PR gets checks only after (1) this lands on `main` **and** (2) its base branch contains this commit — i.e. the stack has to be rebased on (or merged with) `main` once, or the PRs re-based onto `main` as the stack collapses. Until then `gh pr checks` on #29 / #30 keeps reporting "no checks reported".

## Verification

- `python3 -c 'import yaml,sys;yaml.safe_load(open(sys.argv[1]))' .github/workflows/ci.yml` parses; the `on` mapping is `{push: {branches: [main]}, pull_request: null}`.
- This PR targets `main`, so it exercises the trigger itself — CI status below.